### PR TITLE
Exclude module tests from coverage reports

### DIFF
--- a/activities/events.py
+++ b/activities/events.py
@@ -143,9 +143,3 @@ def events_today(now=date.today().strftime("%Y-%m-%d")):
     except (JSONDecodeError, ReadTimeout) as e:
         print(f"Failed to retrieve events. {e}", file=sys.stderr)
         return '<p style="margin:0 0 25px; font-size:12px; line-height:18px; color:#333333;">Ranger program schedule could not be retrieved.</p>'
-
-
-"""if __name__ == "__main__":
-    from dotenv import load_dotenv
-    load_dotenv("email.env")
-    print(events_today('2024-07-01'))"""

--- a/activities/gnpc_events.py
+++ b/activities/gnpc_events.py
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup
 from requests.exceptions import RequestException
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from activities.gnpc_datetime import convert_gnpc_datetimes, datetime_to_string
 
@@ -154,11 +154,3 @@ def get_gnpc_events() -> List[Dict[str, str]]:
         return events
     except Exception as e:
         raise GNPCError(f"Error processing event dates: {str(e)}")
-
-
-"""if __name__ == "__main__":
-    try:
-        print(get_gnpc_events())
-    except GNPCError as e:
-        print(f"Error: {str(e)}")
-        sys.exit(1)"""

--- a/drip/drip_actions.py
+++ b/drip/drip_actions.py
@@ -8,7 +8,7 @@ import json
 import sys
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from drip.subscriber_list import subscriber_list
 from drip.scheduled_subs import update_scheduled_subs
@@ -131,7 +131,3 @@ def send_in_drip(email: str, campaign_id: str = "169298893") -> None:
             r["errors"][0]["message"],
             file=sys.stderr,
         )
-
-
-if __name__ == "__main__":
-    print(get_subs("Glacier Daily Update"))

--- a/drip/scheduled_subs.py
+++ b/drip/scheduled_subs.py
@@ -90,7 +90,3 @@ def update_scheduled_subs():
 
     updates = {"start": start_today, "end": end_today}
     return updates
-
-
-if __name__ == "__main__":
-    print(update_scheduled_subs())

--- a/generate_and_upload.py
+++ b/generate_and_upload.py
@@ -128,5 +128,5 @@ def serve_api():
     send_to_server(printable, "printable")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     serve_api()

--- a/image_otd/flickr.py
+++ b/image_otd/flickr.py
@@ -96,10 +96,3 @@ def get_flickr() -> FlickrImage:
         raise FlickrAPIError(f"Missing environment variable: {str(e)}")
     except Exception as e:
         raise FlickrAPIError(f"Flickr API error: {str(e)}")
-
-
-if __name__ == "__main__":
-    from dotenv import load_dotenv
-
-    load_dotenv("email.env")
-    print(get_flickr())

--- a/image_otd/image_otd.py
+++ b/image_otd/image_otd.py
@@ -15,7 +15,7 @@ from dotenv import load_dotenv
 load_dotenv("email.env")
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from image_otd.flickr import get_flickr
 from shared.retrieve_from_json import retrieve_from_json
@@ -122,7 +122,3 @@ def resize_full() -> Tuple[str, str, str]:
     upload_address = upload_pic_otd()
 
     return upload_address, image_data.title, image_data.link
-
-
-if __name__ == "__main__":
-    print(resize_full())

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ def main(tag: str = "Glacier Daily Update", test: bool = False) -> None:
     bulk_workflow_trigger(subscribers)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser(description="Run Glacier Daily Update")
     parser.add_argument(
         "--tag",

--- a/notices/notices.py
+++ b/notices/notices.py
@@ -10,7 +10,7 @@ from google.oauth2.service_account import Credentials
 from datetime import datetime, timedelta
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from shared.retry import retry
 
@@ -76,10 +76,3 @@ def get_notices():
             pass
 
     return '<p style="margin:0 0 35px; font-size:12px; line-height:18px; color:#333333;">There were no notices for today.</p>'
-
-
-if __name__ == "__main__":
-    from dotenv import load_dotenv
-
-    load_dotenv("email.env")
-    print(get_notices())

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -9,7 +9,7 @@ import os
 import csv
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from peak.sat import peak_sat
 from shared.retrieve_from_json import retrieve_from_json
@@ -46,5 +46,5 @@ def peak(test=False):
     return f"{today['name']} - {today['elevation']} ft.", peak_img, google_maps
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(peak(test=True))

--- a/peak/sat.py
+++ b/peak/sat.py
@@ -16,7 +16,7 @@ from dotenv import load_dotenv
 load_dotenv("email.env")
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from shared.ftp import upload_file
 
@@ -76,7 +76,7 @@ def peak_sat(peak: dict) -> str:
         return "https://glacier.org/daily/summer/peak.jpg"
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     peak_sat(
         {
             "name": "Long Knife Peak",

--- a/product_otd/product.py
+++ b/product_otd/product.py
@@ -18,7 +18,7 @@ from PIL import Image
 load_dotenv("email.env")
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from shared.retrieve_from_json import retrieve_from_json
 from shared.ftp import upload_file
@@ -186,5 +186,5 @@ def get_product():
     )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(get_product())

--- a/roads/HikerBiker.py
+++ b/roads/HikerBiker.py
@@ -6,7 +6,7 @@ import sys
 import os
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from roads.Place import Place
 from roads.Road import Road

--- a/roads/Place.py
+++ b/roads/Place.py
@@ -8,7 +8,7 @@ from typing import Tuple
 from math import radians, sin, cos, sqrt, atan2
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from roads.places import places
 

--- a/roads/hiker_biker.py
+++ b/roads/hiker_biker.py
@@ -10,7 +10,7 @@ import requests
 import urllib3
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from roads.HikerBiker import HikerBiker
 from roads.roads import closed_roads
@@ -117,5 +117,5 @@ def get_hiker_biker_status() -> str:
         return ""
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(get_hiker_biker_status())

--- a/roads/roads.py
+++ b/roads/roads.py
@@ -126,5 +126,5 @@ def get_road_status() -> str:
         return ""
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(get_road_status())

--- a/sunrise_timelapse/sleep_to_sunrise.py
+++ b/sunrise_timelapse/sleep_to_sunrise.py
@@ -46,5 +46,5 @@ def sleep_time():
         sleep(timelapse_ready_in)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sleep_time()

--- a/sunrise_timelapse/vid_frame.py
+++ b/sunrise_timelapse/vid_frame.py
@@ -17,7 +17,7 @@ from dotenv import load_dotenv
 load_dotenv("email.env")
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from shared.retrieve_from_json import retrieve_from_json
 from shared.ftp import upload_file
@@ -293,5 +293,5 @@ def process_video(test: bool = False) -> Tuple[Optional[str], Optional[str]]:
         return None, None
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(process_video(test=True))

--- a/test/test_activities.py
+++ b/test/test_activities.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from activities.events import events_today
 from activities.gnpc_datetime import convert_gnpc_datetimes, datetime_to_string

--- a/test/test_drip.py
+++ b/test/test_drip.py
@@ -6,7 +6,7 @@ import sys
 import os
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from drip.subscriber_list import subscriber_list
 

--- a/test/test_hiker_biker.py
+++ b/test/test_hiker_biker.py
@@ -6,7 +6,7 @@ import requests
 import json
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from roads.hiker_biker import get_hiker_biker_status, hiker_biker
 from roads.HikerBiker import HikerBiker

--- a/test/test_image_otd.py
+++ b/test/test_image_otd.py
@@ -10,7 +10,7 @@ from PIL import Image, UnidentifiedImageError
 
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from image_otd.flickr import FlickrImage, get_flickr, FlickrAPIError
 from image_otd.image_otd import (

--- a/test/test_notices.py
+++ b/test/test_notices.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import gspread
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from notices.notices import get_notices
 

--- a/test/test_potd.py
+++ b/test/test_potd.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import json
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from product_otd.product import get_product, resize_image, upload_potd
 
@@ -187,5 +187,5 @@ class TestUploadPotd:
                 upload_potd()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__])

--- a/test/test_timelapse.py
+++ b/test/test_timelapse.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from sunrise_timelapse.timelapse_json import send_timelapse_data, gen_json
 
@@ -100,5 +100,5 @@ def test_gen_json_sorting():
     ]
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__])

--- a/test/test_timelapse_frame.py
+++ b/test/test_timelapse_frame.py
@@ -9,7 +9,7 @@ import numpy as np
 from PIL import Image
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from sunrise_timelapse.vid_frame import (
     find_frame,

--- a/test/weather/test_aqi_sunset.py
+++ b/test/weather/test_aqi_sunset.py
@@ -7,7 +7,7 @@ import requests
 from datetime import datetime
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.sunset_hue import get_sunset_hue
 from weather.weather_aqi import get_air_quality

--- a/test/weather/test_forecast.py
+++ b/test/weather/test_forecast.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.forecast import WeatherAPI, Location, get_forecast
 
@@ -153,5 +153,5 @@ def test_location_dataclass():
     assert location.altitude == 3000
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__])

--- a/test/weather/test_night_sky.py
+++ b/test/weather/test_night_sky.py
@@ -8,7 +8,7 @@ import json
 from requests.exceptions import RequestException
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.night_sky import (
     Forecast,

--- a/test/weather/test_season.py
+++ b/test/weather/test_season.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import pytest
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.season import get_season
 

--- a/test/weather/test_weather.py
+++ b/test/weather/test_weather.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.weather import WeatherContent, weather_data
 

--- a/test/weather/test_weather_alerts.py
+++ b/test/weather/test_weather_alerts.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import json
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.weather_alerts import WeatherAlertService, WeatherAlert, weather_alerts
 

--- a/test/weather/test_weather_img.py
+++ b/test/weather/test_weather_img.py
@@ -9,7 +9,7 @@ from PIL import Image
 import pytest
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.weather_img import weather_image, upload_weather, _validate_input
 

--- a/trails_and_cgs/frontcountry_cgs.py
+++ b/trails_and_cgs/frontcountry_cgs.py
@@ -108,5 +108,5 @@ def get_campground_status() -> str:
         return ""
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(get_campground_status())

--- a/trails_and_cgs/trails.py
+++ b/trails_and_cgs/trails.py
@@ -137,5 +137,5 @@ def get_closed_trails() -> str:
         return ""
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(get_closed_trails())

--- a/weather/forecast.py
+++ b/weather/forecast.py
@@ -192,6 +192,6 @@ def get_forecast() -> Tuple[List[Tuple[str, int, int, str]], str]:
         ) from e
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     results, length_str = get_forecast()
     print(results, length_str)

--- a/weather/night_sky.py
+++ b/weather/night_sky.py
@@ -381,5 +381,5 @@ def aurora_forecast(cloud_cover: float = 0.0) -> str:
     return cast, msg
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(aurora_forecast(cloud_cover=0.2))

--- a/weather/season.py
+++ b/weather/season.py
@@ -39,5 +39,5 @@ def get_season(date: Optional[datetime] = None) -> str:
         return "fall"
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(get_season())

--- a/weather/sunset_hue.py
+++ b/weather/sunset_hue.py
@@ -51,7 +51,7 @@ def get_sunset_hue(test: bool = False) -> str:
     return cloud_cover, quality_text, msg
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     from dotenv import load_dotenv
 
     load_dotenv("email.env")

--- a/weather/weather.py
+++ b/weather/weather.py
@@ -8,7 +8,7 @@ import concurrent.futures
 from typing import Optional, List, Tuple
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.weather_alerts import weather_alerts
 from weather.night_sky import aurora_forecast
@@ -128,7 +128,7 @@ def weather_data() -> WeatherContent:
     return WeatherContent()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     from dotenv import load_dotenv
 
     load_dotenv("email.env")

--- a/weather/weather_alerts.py
+++ b/weather/weather_alerts.py
@@ -191,5 +191,5 @@ def weather_alerts() -> str:
         return ""
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(weather_alerts())

--- a/weather/weather_aqi.py
+++ b/weather/weather_aqi.py
@@ -53,5 +53,5 @@ def get_air_quality() -> int:
         return ""
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(get_air_quality())

--- a/weather/weather_img.py
+++ b/weather/weather_img.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import List, Tuple, Dict
 
 if sys.path[0] == os.path.dirname(os.path.abspath(__file__)):
-    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path[0] = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # pragma: no cover
 
 from weather.weather import weather_data
 from weather.season import get_season
@@ -141,7 +141,7 @@ def weather_image(results: List[Tuple[str, int, int, str]]) -> str:
     return upload_weather()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     from dotenv import load_dotenv
 
     load_dotenv("email.env")

--- a/web_version.py
+++ b/web_version.py
@@ -72,7 +72,7 @@ def web_version(
     return file_name
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     data = {
         "date": "2024-05-01",
         "today": "May 1, 2024",


### PR DESCRIPTION
Adding a pragma directive to exclude the main execution blocks used for local testing from coverage reports improves the accuracy of test coverage metrics.