### PR TITLE
Improve email template consistency and update Flickr API headers

### DIFF
--- a/email_html/email_template.html
+++ b/email_html/email_template.html
@@ -305,7 +305,7 @@
                                                                         &nbsp;</p>
                                                                 </td>
                                                                 <td>
-                                                                    {% if my.daily_update.image_otd | base64_decode != 'Flickr API Error' %}
+                                                                    {% if my.daily_update.image_otd | base64_decode != "Flickr API Error" %}
                                                                         <a style="display:block; margin:0 0 14px;"
                                                                             href="{{ my.daily_update.image_otd_link | base64_decode }}"><img
                                                                                 src="{{ my.daily_update.image_otd | base64_decode }}"

--- a/image_otd/flickr.py
+++ b/image_otd/flickr.py
@@ -91,7 +91,19 @@ def get_flickr() -> FlickrImage:
 
         req = urllib.request.Request(
             pic_url,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; GlacierDailyBot/1.0)"},
+            headers={
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "DNT": "1",
+                "Connection": "keep-alive",
+                "Upgrade-Insecure-Requests": "1",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "none",
+                "Cache-Control": "max-age=0",
+            },
         )
 
         max_retries = 2


### PR DESCRIPTION
Ensure consistent string comparison in the email template by using double quotes. Update the User-Agent and request headers for improved compatibility with the Flickr API during image retrieval.