### PR TITLE
Merge hiker/biker Road Crew & Hazard closures at same location

### DIFF
--- a/roads/hiker_biker.py
+++ b/roads/hiker_biker.py
@@ -117,6 +117,31 @@ def hiker_biker(road_closures: dict | None = None) -> HikerBikerResult:
                     for idx, _, _ in sorted_entries[1:]:
                         entries[idx][0] = "Avalanche Hazard Closure:"
 
+        # Merge a Road Crew and a Hazard closure that map to the same named
+        # location into a single bullet. Runs after the relabel pass so it also
+        # catches pairs that were disambiguated above.
+        merged_out: set[int] = set()
+        for i in range(len(entries)):
+            if i in merged_out:
+                continue
+            ct_i, hb_i = entries[i]
+            loc_i = hb_i.north_loc[0]
+            if not loc_i or "name of location not found" in loc_i:
+                continue
+            for j in range(i + 1, len(entries)):
+                if j in merged_out:
+                    continue
+                ct_j, hb_j = entries[j]
+                if hb_j.north_loc[0] != loc_i:
+                    continue
+                has_road_crew = "Road Crew" in ct_i or "Road Crew" in ct_j
+                has_hazard = "Hazard" in ct_i or "Hazard" in ct_j
+                if has_road_crew and has_hazard:
+                    entries[i][0] = "Road Crew & Hazard Closure:"
+                    merged_out.add(j)
+                    break
+        entries = [e for idx, e in enumerate(entries) if idx not in merged_out]
+
         statuses = [f"{ct} {hb}" for ct, hb in entries]
 
         # Return empty result if there are no hiker biker restrictions listed.

--- a/test/test_hiker_biker.py
+++ b/test/test_hiker_biker.py
@@ -404,3 +404,48 @@ def test_get_side_north_of_logan(mock_gtsr):
     # Latitude > north_boundary (48.6998) and longitude between boundaries
     hb = HikerBiker("Test North", (-113.72, 48.71), mock_gtsr)
     assert hb.get_side() == "west"
+
+
+def _make_same_location_response(name1: str, name2: str) -> dict:
+    """Build a two-closure API response where both closures resolve to the
+    same named location (The Loop) via slightly offset coordinates."""
+    return {
+        "features": [
+            {
+                "properties": {"name": name1, "description": "", "status": "active"},
+                "geometry": {"coordinates": [-113.80047, 48.75494]},  # The Loop
+            },
+            {
+                "properties": {"name": name2, "description": "", "status": "active"},
+                # Slightly offset but still within 3 km — resolves to The Loop
+                "geometry": {"coordinates": [-113.80200, 48.75600]},
+            },
+        ]
+    }
+
+
+def test_road_crew_and_hazard_same_location_merged(mock_gtsr):
+    """Road Crew and Avalanche Hazard resolving to the same named location
+    merge into a single 'Road Crew & Hazard Closure:' bullet."""
+    result = _run_duplicate_test(
+        _make_same_location_response(
+            "Hiker/Biker Road Crew Closure", "Avalanche Hazard Closure"
+        ),
+        mock_gtsr,
+    )
+    assert len(result.closures) == 1
+    assert result.closures[0].startswith("Road Crew & Hazard Closure:")
+    assert "The Loop" in result.closures[0]
+
+
+def test_duplicate_road_crew_same_location_merged(mock_gtsr):
+    """Two Road Crew closures resolving to the same named location get
+    relabeled into a Road Crew/Avalanche pair, then merged into one bullet."""
+    result = _run_duplicate_test(
+        _make_same_location_response(
+            "Hiker/Biker Road Crew Closure", "Hiker/Biker Road Crew Closure"
+        ),
+        mock_gtsr,
+    )
+    assert len(result.closures) == 1
+    assert result.closures[0].startswith("Road Crew & Hazard Closure:")


### PR DESCRIPTION
## Summary
- When a Road Crew Closure and a Hazard Closure resolve to the same named location, combine them into a single `Road Crew & Hazard Closure:` bullet instead of listing two near-identical entries.
- Runs after the existing duplicate-relabel pass so it also collapses pairs that were disambiguated there (e.g. two Road Crew entries at the same spot).
- Match uses `hb.north_loc[0]` — the named location resolved via `Place.find_min_distance` within the 3 km `LOCATION_MATCH_DISTANCE_KM` threshold — so slightly offset coordinates still merge.

## Test plan
- [x] `uv run pytest test/test_hiker_biker.py` (24 passed, 2 new)
- [x] `uv run ruff check` / `uv run ruff format` / `uv run ty check`
- [x] New test: Road Crew + Avalanche Hazard at offset coords resolving to The Loop → one merged bullet
- [x] New test: Two Road Crew closures at offset coords → relabel pass + merge → one bullet