### PR TITLE
Prefer open status when feed has duplicate campground rows

### DIFF
--- a/trails_and_cgs/frontcountry_cgs.py
+++ b/trails_and_cgs/frontcountry_cgs.py
@@ -67,10 +67,18 @@ def campground_alerts() -> CampgroundsResult:
     season_closures = []
     statuses = []
 
+    # The feed occasionally carries duplicate rows for a campground with
+    # conflicting status (a stale "closed" row left alongside the live "open"
+    # one). Treat a campground as open if any of its rows reports open, so a
+    # stale closure can't override a current opening.
+    open_names = {
+        i["name"].replace("  ", " ") for i in campgrounds if i["status"] != "closed"
+    }
+
     for i in campgrounds:
         name = i["name"].replace("  ", " ")
 
-        if i["status"] == "closed":
+        if i["status"] == "closed" and name not in open_names:
             if name in YEAR_ROUND_CAMPGROUNDS:
                 closures.append(f"{name} CG: currently closed.")
             elif (


### PR DESCRIPTION
## Problem

Sprague Creek was being reported as "Not yet open for the season" in the daily email even though it is open.

The NPS Glacier Live feed (`glac_front_country_campgrounds`) carries **two contradictory rows** for Sprague Creek — a stale `closed`/"Closed for the season" row left alongside the correct `open` row. The closure logic looped over every row and let the stale `closed` row win.

Sprague Creek is currently the only duplicated campground (14 rows, 13 unique names), but the feed is live and NPS-maintained, so this could happen to any campground.

## Fix

Dedupe by name: build a set of campground names that have any `open` row, and skip the closure logic for those. A stale "closed" row can no longer override a live "open" one.

## Verification

- Confirmed against the live feed: Sprague Creek now drops out of the closure list.
- All 12 existing `test_frontcountry_cgs.py` tests pass.
- ruff check / format / ty all clean.