### PR TITLE
Fix duplicate-email retry bug, harden status reporting, refactor gen_data

### DIFF
--- a/activities/events.py
+++ b/activities/events.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 NPS_EVENTS_PAGE_SIZE = 10
 
 
-def time_sortable(time: str):
+def time_sortable(time: str) -> datetime:
     """
     Convert a time string to a datetime object that is sortable.
 
@@ -35,7 +35,7 @@ def time_sortable(time: str):
 
 
 @retry(3, (requests.exceptions.RequestException,), default=None, backoff=5)
-def fetch_events(endpoint, headers):
+def fetch_events(endpoint: str, headers: dict) -> tuple[list, int] | None:
     """Get events from endpoint."""
     response = requests.get(endpoint, headers=headers, timeout=15)
     response.raise_for_status()

--- a/drip/scheduled_subs.py
+++ b/drip/scheduled_subs.py
@@ -13,7 +13,7 @@ from shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-def start(subs: list):
+def start(subs: list) -> None:
     """
     Start the daily updates for the given list of subscribers.
 
@@ -31,7 +31,7 @@ def start(subs: list):
         update_subscriber(updates)
 
 
-def end(subs: list):
+def end(subs: list) -> None:
     """
     End the daily updates for the given list of subscribers.
 
@@ -48,7 +48,7 @@ def end(subs: list):
         update_subscriber(updates)
 
 
-def update_scheduled_subs():
+def update_scheduled_subs() -> dict[str, list[str]]:
     """
     Update the scheduled subscribers by checking their start and end dates.
 

--- a/generate_and_upload.py
+++ b/generate_and_upload.py
@@ -4,11 +4,16 @@ Generate all of the data with a ThreadPoolExecutor, then upload it to the glacie
 server with FTP.
 """
 
+import argparse
 import concurrent.futures
 import json
 import os
-from dataclasses import asdict
+import sys
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from dataclasses import fields as dataclass_fields
 from time import sleep
+from typing import Any
 
 import requests
 
@@ -22,7 +27,9 @@ from product_otd.product import get_product, prepare_potd_upload
 from roads.hiker_biker import get_hiker_biker_status
 from roads.roads import get_road_status
 from shared.data_types import (
+    AlertBullet,
     CampgroundsResult,
+    Event,
     EventsResult,
     HikerBikerResult,
     NoticesResult,
@@ -37,7 +44,9 @@ from shared.datetime_utils import (
 )
 from shared.ftp import FTPSession
 from shared.lkg_cache import LKGCache
-from shared.logging_config import get_logger
+from shared.logging_config import get_logger, setup_logging
+from shared.run_context import start_run
+from shared.run_report import complete_run
 from shared.settings import get_settings
 from shared.timing import timed
 from sunrise_timelapse.get_timelapse import process_video
@@ -50,37 +59,109 @@ from web_version import web_version
 logger = get_logger(__name__)
 
 
-# Date-deterministic: checked BEFORE API call, skip if cached today
-CACHED_MODULE_KEYS = {
-    "peak": ["peak", "peak_image", "peak_map"],
-    "image_otd": ["image_otd", "image_otd_title", "image_otd_link"],
-    "product": ["product_title", "product_image", "product_link", "product_desc"],
+@dataclass(frozen=True)
+class ModuleSpec:
+    """Declares how one data module plugs into gen_data().
+
+    Adding a module means adding one entry to MODULES — the fetch,
+    timing, LKG caching, and template-field assembly are all driven
+    from this spec.
+    """
+
+    name: str  # LKG module name and timing label
+    func: Callable[..., Any]  # module entrypoint; re-resolved by name at submit time
+    fields: tuple[str, ...]  # template field keys, in result-tuple order
+    default_factory: Callable[[], Any]  # result when fetch and LKG both fail
+    # Date-deterministic modules treat LKG as a primary cache: if today's
+    # data exists, the fetch is skipped entirely. Dynamic modules always
+    # fetch fresh and use LKG only as a fallback (lkg_fallback).
+    date_deterministic: bool = False
+    lkg_fallback: bool = True
+    # Extra template fields saved under this module's LKG entry that the
+    # module callable itself doesn't produce (e.g. weather_image)
+    extra_lkg_keys: tuple[str, ...] = ()
+
+
+MODULES: tuple[ModuleSpec, ...] = (
+    # Weather's LKG fallback is handled after the pool drains (not via
+    # lkg_fallback) because the derived weather_image field and the
+    # pending-uploads list must stay in sync with it.
+    ModuleSpec(
+        "weather",
+        weather_data,
+        ("weather",),
+        WeatherResult,
+        lkg_fallback=False,
+        extra_lkg_keys=("weather_image",),
+    ),
+    ModuleSpec("trails", get_closed_trails, ("trails",), TrailsResult),
+    ModuleSpec(
+        "campgrounds", get_campground_status, ("campgrounds",), CampgroundsResult
+    ),
+    ModuleSpec("roads", get_road_status, ("roads",), RoadsResult),
+    ModuleSpec(
+        "hiker_biker", get_hiker_biker_status, ("hikerbiker",), HikerBikerResult
+    ),
+    ModuleSpec("events", events_today, ("events",), EventsResult),
+    ModuleSpec(
+        "sunrise",
+        process_video,
+        ("sunrise_vid", "sunrise_still", "sunrise_str"),
+        lambda: ("", "", ""),
+    ),
+    ModuleSpec("notices", get_notices, ("notices",), NoticesResult),
+    # Each module's caching behavior (primary cache vs. fallback vs. none)
+    # is deliberate — don't change these flags without checking first
+    ModuleSpec(
+        "gnpc_events", get_gnpc_events, ("gnpc-events",), list, lkg_fallback=False
+    ),
+    # Date-deterministic modules use LKG as a primary cache (checked before
+    # the fetch), not as a failure fallback — on a cache miss + fetch failure
+    # they return their empty defaults
+    ModuleSpec(
+        "image_otd",
+        get_image_otd,
+        ("image_otd", "image_otd_title", "image_otd_link"),
+        lambda: ("", "", ""),
+        date_deterministic=True,
+        lkg_fallback=False,
+    ),
+    ModuleSpec(
+        "peak",
+        peak,
+        ("peak", "peak_image", "peak_map"),
+        lambda: ("", None, ""),
+        date_deterministic=True,
+        lkg_fallback=False,
+    ),
+    ModuleSpec(
+        "product",
+        get_product,
+        ("product_title", "product_image", "product_link", "product_desc"),
+        lambda: ("", None, "", ""),
+        date_deterministic=True,
+        lkg_fallback=False,
+    ),
+)
+
+# Maps every template field key to the LKG module that owns it
+# (serve_api uses this to save resolved image URLs after upload)
+_FIELD_TO_MODULE = {
+    key: spec.name for spec in MODULES for key in (*spec.fields, *spec.extra_lkg_keys)
 }
 
-# Dynamic: always fetch fresh, LKG used only as fallback on failure
-FALLBACK_MODULE_KEYS = {
-    "weather": ["weather", "weather_image"],
-    "trails": ["trails"],
-    "campgrounds": ["campgrounds"],
-    "roads": ["roads"],
-    "hiker_biker": ["hikerbiker"],
-    "events": ["events"],
-    "notices": ["notices"],
-    "sunrise": ["sunrise_vid", "sunrise_still", "sunrise_str"],
-    "gnpc_events": ["gnpc-events"],
+# Template fields holding dataclasses, which LKG stores as JSON text
+_FIELD_DATACLASSES: dict[str, type] = {
+    "weather": WeatherResult,
+    "events": EventsResult,
+    "trails": TrailsResult,
+    "campgrounds": CampgroundsResult,
+    "roads": RoadsResult,
+    "hikerbiker": HikerBikerResult,
+    "notices": NoticesResult,
 }
-
-_ALL_MODULE_KEYS = {**CACHED_MODULE_KEYS, **FALLBACK_MODULE_KEYS}
 
 _CACHE_PURGE_PROPAGATION_SECS = 3
-
-# Maps pending_upload field keys to their LKG module name
-_FIELD_TO_MODULE = {
-    "image_otd": "image_otd",
-    "peak_image": "peak",
-    "product_image": "product",
-    "weather_image": "weather",
-}
 
 
 def _is_substantive(value) -> bool:
@@ -99,7 +180,7 @@ def _is_substantive(value) -> bool:
 def _save_module_lkg(module_name, data):
     """Save successful module output to LKG cache.
 
-    Dataclass values are serialized to JSON strings for storage.
+    Dataclass and list values are serialized to JSON strings for storage.
     """
     try:
         cache = LKGCache.get_cache()
@@ -111,12 +192,15 @@ def _save_module_lkg(module_name, data):
                 serialized[k] = json.dumps(_serialize_value(v))
             elif isinstance(v, str):
                 serialized[k] = v
+            elif isinstance(v, list | dict):
+                serialized[k] = json.dumps(v, default=str)
             else:
                 serialized[k] = str(v)
         if serialized:
             cache.save(module_name, serialized)
     except Exception:
-        logger.debug("Failed to save LKG for %s", module_name, exc_info=True)
+        # A broken cache means fallbacks silently stop working — make it visible
+        logger.warning("Failed to save LKG for %s", module_name, exc_info=True)
 
 
 def _load_module_lkg(module_name, keys):
@@ -124,8 +208,44 @@ def _load_module_lkg(module_name, keys):
     try:
         return LKGCache.get_cache().load(module_name, keys)
     except Exception:
-        logger.debug("Failed to load LKG for %s", module_name, exc_info=True)
+        logger.warning("Failed to load LKG for %s", module_name, exc_info=True)
         return None
+
+
+def _dataclass_from_dict(cls: type, payload: dict) -> Any:
+    """Rebuild a result dataclass from its asdict() representation."""
+    if cls is EventsResult:
+        payload["events"] = [Event(**e) for e in payload.get("events", [])]
+    elif cls is WeatherResult:
+        payload["forecasts"] = [tuple(f) for f in payload.get("forecasts", [])]
+        payload["alerts"] = [AlertBullet(**a) for a in payload.get("alerts", [])]
+    names = {f.name for f in dataclass_fields(cls)}
+    return cls(**{k: v for k, v in payload.items() if k in names})
+
+
+def _deserialize_field(key: str, value: Any) -> Any:
+    """Convert an LKG-stored string back to the field's runtime type.
+
+    The LKG cache stores everything as TEXT: dataclasses and lists as
+    JSON, plain string fields verbatim. Templates need the structured
+    types back — handing them a JSON string renders as an empty section.
+    """
+    if not isinstance(value, str):
+        return value
+    cls = _FIELD_DATACLASSES.get(key)
+    if cls is not None:
+        try:
+            return _dataclass_from_dict(cls, json.loads(value))
+        except (ValueError, TypeError):
+            logger.warning("Could not deserialize LKG value for '%s'", key)
+            return cls()
+    if key == "gnpc-events":
+        try:
+            return json.loads(value)
+        except ValueError:
+            logger.warning("Could not deserialize LKG value for '%s'", key)
+            return []
+    return value
 
 
 def _submit_timed(executor, name, func, *args, **kwargs):
@@ -151,9 +271,10 @@ def _safe_result(future, name, default, lkg_keys=None):
             lkg_data = _load_module_lkg(name, lkg_keys)
             if lkg_data:
                 logger.info("Using LKG fallback for '%s'", name)
-                if len(lkg_keys) == 1:
-                    return lkg_data[lkg_keys[0]]
-                return tuple(lkg_data.get(k, "") for k in lkg_keys)
+                values = tuple(
+                    _deserialize_field(k, lkg_data.get(k, "")) for k in lkg_keys
+                )
+                return values[0] if len(values) == 1 else values
         return default
 
 
@@ -177,85 +298,46 @@ def gen_data() -> tuple[dict, list]:
             images that still need to be uploaded via FTPSession.upload().
     """
 
-    # Check LKG cache for date-deterministic modules
-    cached = {}
-    for module_name, keys in CACHED_MODULE_KEYS.items():
-        lkg_data = _load_module_lkg(module_name, keys)
+    # Date-deterministic modules: LKG is a primary cache, skip fetch on a hit
+    cached: dict[str, dict[str, str]] = {}
+    for spec in MODULES:
+        if not spec.date_deterministic:
+            continue
+        lkg_data = _load_module_lkg(spec.name, list(spec.fields))
         if lkg_data:
-            cached[module_name] = lkg_data
-            logger.info("Using cached data for '%s' (date-deterministic)", module_name)
+            cached[spec.name] = lkg_data
+            logger.info("Using cached data for '%s' (date-deterministic)", spec.name)
 
+    fields: dict[str, Any] = {}
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        # Dynamic modules: always fetch fresh
-        weather_future = _submit_timed(executor, "weather", weather_data)
-        trails_future = _submit_timed(executor, "trails", get_closed_trails)
-        cg_future = _submit_timed(executor, "campgrounds", get_campground_status)
-        roads_future = _submit_timed(executor, "roads", get_road_status)
-        hiker_biker_future = _submit_timed(
-            executor, "hiker_biker", get_hiker_biker_status
-        )
-        events_future = _submit_timed(executor, "events", events_today)
-        sunrise_future = _submit_timed(executor, "sunrise", process_video)
-        notices_future = _submit_timed(executor, "notices", get_notices)
-        gnpc_future = _submit_timed(executor, "gnpc_events", get_gnpc_events)
+        futures = {}
+        module_globals = globals()
+        for spec in MODULES:
+            if spec.name in cached:
+                continue
+            # Re-resolved by name at submit time (not registry-build time)
+            # so tests can monkeypatch the module-level callables
+            func_name = getattr(spec.func, "__name__", "")
+            func = module_globals.get(func_name, spec.func)
+            kwargs = {"skip_upload": True} if spec.date_deterministic else {}
+            futures[spec.name] = _submit_timed(executor, spec.name, func, **kwargs)
 
-        # Date-deterministic modules: skip if cached today
-        image_future = None
-        if "image_otd" not in cached:
-            image_future = _submit_timed(
-                executor, "image_otd", get_image_otd, skip_upload=True
-            )
-        peak_future = None
-        if "peak" not in cached:
-            peak_future = _submit_timed(executor, "peak", peak, skip_upload=True)
-        product_future = None
-        if "product" not in cached:
-            product_future = _submit_timed(
-                executor, "product", get_product, skip_upload=True
-            )
+        for spec in MODULES:
+            if spec.name in cached:
+                values = tuple(cached[spec.name].get(k, "") for k in spec.fields)
+            else:
+                lkg_keys = list(spec.fields) if spec.lkg_fallback else None
+                result = _safe_result(
+                    futures[spec.name],
+                    spec.name,
+                    spec.default_factory(),
+                    lkg_keys=lkg_keys,
+                )
+                values = result if len(spec.fields) > 1 else (result,)
+            fields.update(zip(spec.fields, values, strict=True))
 
-        # Extract dynamic module results (with LKG fallback)
-        sunrise_vid, sunrise_still, sunrise_str = _safe_result(
-            sunrise_future,
-            "sunrise",
-            ("", "", ""),
-            lkg_keys=["sunrise_vid", "sunrise_still", "sunrise_str"],
-        )
-        weather = _safe_result(weather_future, "weather", WeatherResult())
-
-        # Extract date-deterministic results from cache or futures
-        if "image_otd" in cached:
-            c = cached["image_otd"]
-            image_otd = c.get("image_otd", "")
-            image_otd_title = c.get("image_otd_title", "")
-            image_otd_link = c.get("image_otd_link", "")
-        else:
-            image_otd, image_otd_title, image_otd_link = _safe_result(
-                image_future, "image_otd", ("", "", "")
-            )
-
-        if "peak" in cached:
-            c = cached["peak"]
-            peak_name = c.get("peak", "")
-            peak_img = c.get("peak_image")
-            peak_map = c.get("peak_map", "")
-        else:
-            peak_name, peak_img, peak_map = _safe_result(
-                peak_future, "peak", ("", None, "")
-            )
-
-        if "product" in cached:
-            c = cached["product"]
-            potd_title = c.get("product_title", "")
-            potd_image = c.get("product_image")
-            potd_link = c.get("product_link", "")
-            potd_desc = c.get("product_desc", "")
-        else:
-            potd_title, potd_image, potd_link, potd_desc = _safe_result(
-                product_future, "product", ("", None, "", "")
-            )
-
-    weather_img = (
+    weather = fields["weather"]
+    fields["weather_image"] = (
         weather_image(weather.forecasts, skip_upload=True)
         if weather.forecasts
         else None
@@ -263,76 +345,44 @@ def gen_data() -> tuple[dict, list]:
 
     # Collect deferred image uploads for the caller to process
     pending_uploads = []
-    if image_otd is None:
+    if fields["image_otd"] is None:
         pending_uploads.append(("image_otd", prepare_pic_otd()))
-    if peak_img is None:
+    if fields["peak_image"] is None:
         pending_uploads.append(("peak_image", prepare_peak_upload()))
-    if potd_image is None:
+    if fields["product_image"] is None:
         pending_uploads.append(("product_image", prepare_potd_upload()))
-    if weather_img is None:
+    if fields["weather_image"] is None:
         pending_uploads.append(("weather_image", prepare_weather_upload()))
 
-    drip_template_fields = {
-        "date": now_mountain().strftime("%Y-%m-%d"),
-        "today": format_date_readable(now_mountain()),
-        "events": _safe_result(
-            events_future, "events", EventsResult(), lkg_keys=["events"]
-        ),
-        "weather": weather,
-        "weather_image": weather_img,
-        "trails": _safe_result(
-            trails_future, "trails", TrailsResult(), lkg_keys=["trails"]
-        ),
-        "campgrounds": _safe_result(
-            cg_future, "campgrounds", CampgroundsResult(), lkg_keys=["campgrounds"]
-        ),
-        "roads": _safe_result(roads_future, "roads", RoadsResult(), lkg_keys=["roads"]),
-        "hikerbiker": _safe_result(
-            hiker_biker_future,
-            "hiker_biker",
-            HikerBikerResult(),
-            lkg_keys=["hikerbiker"],
-        ),
-        "notices": _safe_result(
-            notices_future, "notices", NoticesResult(), lkg_keys=["notices"]
-        ),
-        "peak": peak_name,
-        "peak_image": peak_img,
-        "peak_map": peak_map,
-        "product_link": potd_link,
-        "product_image": potd_image,
-        "product_title": potd_title,
-        "product_desc": potd_desc,
-        "image_otd": image_otd,
-        "image_otd_title": image_otd_title,
-        "image_otd_link": image_otd_link,
-        "sunrise_vid": sunrise_vid,
-        "sunrise_still": sunrise_still,
-        "sunrise_str": sunrise_str,
-        "gnpc-events": _safe_result(gnpc_future, "gnpc_events", []),
-    }
-
-    # LKG: Apply weather fallback if weather module failed
-    if not drip_template_fields["weather"].daylight_message:
+    # LKG: Apply weather fallback if weather module failed. Handled here
+    # rather than via lkg_fallback so the cached weather_image URL can
+    # replace the pending weather-image upload.
+    if not fields["weather"].daylight_message:
         lkg = _load_module_lkg("weather", ["weather", "weather_image"])
         if lkg:
             logger.info("Using LKG fallback for 'weather'")
-            drip_template_fields["weather"] = lkg.get("weather", WeatherResult())
+            fields["weather"] = _deserialize_field("weather", lkg["weather"])
             if lkg.get("weather_image"):
-                drip_template_fields["weather_image"] = lkg["weather_image"]
+                fields["weather_image"] = lkg["weather_image"]
                 pending_uploads[:] = [
                     (k, v) for k, v in pending_uploads if k != "weather_image"
                 ]
 
     # LKG: Save successful module data
-    for module_name, keys in _ALL_MODULE_KEYS.items():
+    for spec in MODULES:
         module_data = {
-            k: drip_template_fields[k]
-            for k in keys
-            if _is_substantive(drip_template_fields.get(k))
+            k: fields[k]
+            for k in (*spec.fields, *spec.extra_lkg_keys)
+            if _is_substantive(fields.get(k))
         }
         if module_data:
-            _save_module_lkg(module_name, module_data)
+            _save_module_lkg(spec.name, module_data)
+
+    drip_template_fields = {
+        "date": now_mountain().strftime("%Y-%m-%d"),
+        "today": format_date_readable(now_mountain()),
+        **fields,
+    }
 
     # Replace None with "" for simple string fields
     for key, value in drip_template_fields.items():
@@ -431,15 +481,20 @@ def clear_cache():
     if os.path.exists(cache_file):
         os.remove(cache_file)
     try:
-        LKGCache.get_cache().clear_modules(list(CACHED_MODULE_KEYS))
+        LKGCache.get_cache().clear_modules(
+            [spec.name for spec in MODULES if spec.date_deterministic]
+        )
     except Exception:
-        logger.debug("Failed to clear LKG cache", exc_info=True)
+        logger.warning("Failed to clear LKG cache", exc_info=True)
 
 
-def serve_api(force: bool = False):
+def serve_api(force: bool = False) -> dict:
     """
     Get the data, then upload it to server for API.
     FTP session is created after data collection to avoid idle timeouts.
+
+    Returns the generated template-field dict so callers (main.py) can
+    sanity-check content before sending the email.
     """
     if force:
         clear_cache()
@@ -467,69 +522,63 @@ def serve_api(force: bool = False):
         sleep(_CACHE_PURGE_PROPAGATION_SECS)
         refresh_cache()
 
+    return data
 
-if __name__ == "__main__":  # pragma: no cover
-    import argparse as _argparse
-    import sys as _sys
 
-    from shared.logging_config import get_log_capture, setup_logging
-    from shared.run_context import start_run
-    from shared.run_report import build_report, upload_status_report
+def run_health_check() -> int:
+    """Validate data generation and FTP connectivity without writing anything.
+
+    Used by the deploy pipeline (``--check``) as its rollback gate.
+    Exceptions propagate so the caller exits nonzero on any failure.
+    """
+    logger.info("Running health check (no data will be written)")
+    gen_data()
+    logger.info("Data generation OK, testing FTP connectivity")
+    with FTPSession():
+        pass  # Login + quit validates credentials and connectivity
+    logger.info("Health check passed")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the hourly web-update run."""
+    parser = argparse.ArgumentParser(description="Generate and upload data")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Clear cached data and re-fetch everything fresh",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Health check only: validate data generation and FTP connectivity without writing",
+    )
+    args = parser.parse_args(argv)
 
     settings = get_settings()  # Load email.env so ENVIRONMENT is available
     run = start_run("web_update")
     setup_logging()
     logger.info("Starting run %s (type=%s)", run.run_id, run.run_type)
 
-    _parser = _argparse.ArgumentParser(description="Generate and upload data")
-    _parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Clear cached data and re-fetch everything fresh",
-    )
-    _parser.add_argument(
-        "--check",
-        action="store_true",
-        help="Health check only: validate data generation and FTP connectivity without writing",
-    )
-    _args = _parser.parse_args()
+    if args.check:
+        return run_health_check()
 
-    if _args.check:
-        # Health check: validate data generation (dev mode) + FTP connectivity
-        logger.info("Running health check (no data will be written)")
-        gen_data()
-        logger.info("Data generation OK, testing FTP connectivity")
-        from shared.ftp import FTPSession
-
-        with FTPSession():
-            pass  # Login + quit validates credentials and connectivity
-        logger.info("Health check passed")
-        _sys.exit(0)
-
-    if _args.force:
+    if args.force:
         clear_cache()
 
-    _run_error = False
+    run_error = False
     try:
-        environment = settings.ENVIRONMENT
-        if environment == "development":
+        if settings.ENVIRONMENT == "development":
             gen_data()  # Pending uploads ignored in development
-        elif environment == "production":
-            serve_api(force=_args.force)
+        elif settings.ENVIRONMENT == "production":
+            serve_api(force=args.force)
     except Exception:
         logger.exception("generate_and_upload failed")
-        _run_error = True
+        run_error = True
     finally:
-        report = build_report(environment=settings.ENVIRONMENT)
-        if _run_error:
-            report.overall_status = "failure"
-        report.finalize_status()
-        logger.info("Run complete: %s", report.overall_status)
-        capture = get_log_capture()
-        if capture:
-            report.log_lines = list(capture.buffer)
-        if settings.ENVIRONMENT == "production":
-            try:
-                upload_status_report(report)
-            except Exception:
-                logger.exception("Failed to upload status report")
+        complete_run(settings.ENVIRONMENT, failed=run_error)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/main.py
+++ b/main.py
@@ -13,9 +13,9 @@ from drip.drip_actions import bulk_workflow_trigger, get_subs
 from generate_and_upload import serve_api
 from shared.config_validation import validate_config
 from shared.lock import acquire_lock, release_lock
-from shared.logging_config import get_log_capture, get_logger, setup_logging
+from shared.logging_config import get_logger, setup_logging
 from shared.run_context import start_run
-from shared.run_report import build_report, upload_status_report
+from shared.run_report import RunReport, complete_run
 from shared.settings import get_settings
 from sunrise_timelapse.sleep_to_sunrise import sleep_time as sleep_to_sunrise
 
@@ -79,36 +79,30 @@ def main(
             logger.exception("%s failed", phase)
             run_error = f"{phase} raised an exception (see logs)"
         finally:
-            report = build_report(environment=settings.ENVIRONMENT)
-            report.subscriber_count = len(subscribers)
-            if batch_result:
-                report.email_delivery = {
-                    "sent": batch_result.sent,
-                    "failed": batch_result.failed,
-                }
-            if run_error:
-                report.errors.append(run_error)
-                if not batch_result:
-                    report.email_delivery = {"sent": 0, "failed": 0}
-                report.overall_status = "failure"
-            if canary_result is not None:
-                report.email_delivery["canary_verified"] = canary_result.verified
-                report.email_delivery["canary_message"] = canary_result.message
-                report.email_delivery["canary_elapsed_seconds"] = (
-                    canary_result.elapsed_seconds
-                )
-            report.finalize_status()
-            # Log status before building the report so it's captured in log_lines
-            logger.info("Run complete: %s", report.overall_status)
-            # Re-snapshot log buffer to include the status line and any error tracebacks
-            capture = get_log_capture()
-            if capture:
-                report.log_lines = list(capture.buffer)
-            if settings.ENVIRONMENT == "production":
-                try:
-                    upload_status_report(report)
-                except Exception:
-                    logger.exception("Failed to upload status report")
+
+            def _decorate(report: RunReport) -> None:
+                report.subscriber_count = len(subscribers)
+                if batch_result:
+                    report.email_delivery = {
+                        "sent": batch_result.sent,
+                        "failed": batch_result.failed,
+                    }
+                if run_error:
+                    report.errors.append(run_error)
+                    if not batch_result:
+                        report.email_delivery = {"sent": 0, "failed": 0}
+                if canary_result is not None:
+                    report.email_delivery["canary_verified"] = canary_result.verified
+                    report.email_delivery["canary_message"] = canary_result.message
+                    report.email_delivery["canary_elapsed_seconds"] = (
+                        canary_result.elapsed_seconds
+                    )
+
+            complete_run(
+                settings.ENVIRONMENT,
+                failed=bool(run_error),
+                decorate=_decorate,
+            )
     finally:
         release_lock(lock_fd)
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,28 @@ from sunrise_timelapse.sleep_to_sunrise import sleep_time as sleep_to_sunrise
 logger = get_logger(__name__)
 
 
+def email_content_ok(data: dict) -> bool:
+    """Check the generated data has enough real content to be worth emailing.
+
+    Sending a hollow email (every core section empty) is worse than not
+    sending — wrong/empty info erodes trust more than a missed day. The
+    email is considered sendable if at least one core section (weather,
+    roads, trails) has substantive content. LKG fallbacks make an
+    all-empty result rare: it means every core module failed with no
+    good data from earlier in the day.
+    """
+    weather = data.get("weather")
+    if getattr(weather, "daylight_message", "") or getattr(weather, "forecasts", []):
+        return True
+    roads = data.get("roads")
+    if getattr(roads, "closures", []) or getattr(roads, "no_closures_message", ""):
+        return True
+    trails = data.get("trails")
+    return bool(
+        getattr(trails, "closures", []) or getattr(trails, "no_closures_message", "")
+    )
+
+
 def main(
     tag: str = "Glacier Daily Update", test: bool = False, force: bool = False
 ) -> None:
@@ -61,8 +83,14 @@ def main(
                 raise RuntimeError("No subscribers retrieved — Drip API may be down")
 
             # Generate data and upload to website.
-            serve_api(force=force)
+            data = serve_api(force=force)
             api_complete = True
+
+            if not email_content_ok(data):
+                raise RuntimeError(
+                    "Email content check failed: weather, roads, and trails "
+                    "are all empty — not sending a hollow email"
+                )
 
             # Allow time for FTP-uploaded timelapse assets to propagate.
             _TIMELAPSE_PROPAGATION_WAIT = 0 if test else 10

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -34,7 +34,7 @@ def _get_peak_summary(name: str, lat: float, lon: float) -> str | None:
     return None
 
 
-def peak(test=False, skip_upload: bool = False):
+def peak(test: bool = False, skip_upload: bool = False) -> tuple[str, str | None, str]:
     """
     Select a random peak, and return the relevant information.
     """

--- a/product_otd/product.py
+++ b/product_otd/product.py
@@ -53,7 +53,7 @@ def prepare_potd_upload() -> tuple[str, str, str]:
     return "product", filename, "email_images/today/product_otd.jpg"
 
 
-def upload_potd():
+def upload_potd() -> str:
     """
     Upload the product image to the glacier.org ftp server.
     """
@@ -139,7 +139,7 @@ def _build_product_data(node: dict) -> dict | None:
     }
 
 
-def get_product(skip_upload: bool = False):
+def get_product(skip_upload: bool = False) -> tuple[str, str | None, str, str]:
     """
     Grab a random product from the Shopify Storefront API.
     """

--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ uv run python -W ignore -m peak.peak
 **Entry Points:**
 - `main.py` - Full pipeline: data collection, FTP upload, email delivery
 - `generate_and_upload.py` - Data collection and FTP upload only (used for web version updates)
-- `retry_check.py` - Cron-driven retry checker: retriggers `main.py` if today has no successful email run
+- `retry_check.py` - Cron-driven retry checker: retriggers `main.py` if today's email hasn't gone out (a partial run that already delivered emails does not retrigger)
 - `web_version.py` - Generates the web version of the daily update via Liquid-to-Jinja2 template rendering
 
 **Data Source Modules:**

--- a/retry_check.py
+++ b/retry_check.py
@@ -34,7 +34,15 @@ PROJECT_DIR = Path(__file__).resolve().parent
 
 
 def has_successful_email_today() -> bool:
-    """Check if today has a successful email run in status.json."""
+    """Check if today's email has already gone out, per status.json.
+
+    A run counts if it finished with overall_status "success" OR if it
+    actually delivered to at least one subscriber (email_delivery.sent > 0).
+    The second condition matters: a run where one data module failed is
+    marked "partial" (or "failure" if a later step raised), but the email
+    still went out — relaunching main.py would send every subscriber a
+    duplicate email.
+    """
     if not STATUS_FILE.exists():
         return False
     try:
@@ -45,11 +53,13 @@ def has_successful_email_today() -> bool:
 
     today = now_mountain().strftime("%Y-%m-%d")
     for run in data.get("runs", []):
-        if (
-            run.get("run_type") == "email"
-            and run.get("overall_status") == "success"
-            and run.get("start_time", "").startswith(today)
-        ):
+        if run.get("run_type") != "email":
+            continue
+        if not run.get("start_time", "").startswith(today):
+            continue
+        if run.get("overall_status") == "success":
+            return True
+        if run.get("email_delivery", {}).get("sent", 0) > 0:
             return True
     return False
 

--- a/shared/config_validation.py
+++ b/shared/config_validation.py
@@ -9,7 +9,7 @@ cryptic failures mid-execution.
 import sys
 
 from shared.logging_config import get_logger
-from shared.settings import ConfigError, get_settings
+from shared.settings import ConfigError, get_settings, required_setting_names
 
 logger = get_logger(__name__)
 
@@ -32,18 +32,10 @@ def validate_config() -> None:
         logger.error(str(exc))
         sys.exit(1)
 
-    # Check that required fields are not empty strings
+    # Check that required fields (derived from the Settings dataclass)
+    # are not empty strings
     missing_required = [
-        name
-        for name in (
-            "NPS",
-            "DRIP_TOKEN",
-            "DRIP_ACCOUNT",
-            "FTP_USERNAME",
-            "FTP_PASSWORD",
-            "MAPBOX_TOKEN",
-        )
-        if not getattr(settings, name)
+        name for name in required_setting_names() if not getattr(settings, name)
     ]
 
     for var in OPTIONAL_VARS:

--- a/shared/data_types.py
+++ b/shared/data_types.py
@@ -19,7 +19,9 @@ class Event:
     name: str  # "Creekside Stroll"
     location: str  # "Apgar VC"
     link: str  # NPS event URL
-    sortable: datetime  # For sort ordering (excluded from JSON serialization)
+    # For sort ordering; excluded from JSON serialization, so events
+    # rebuilt from the LKG cache carry None (list order is already sorted)
+    sortable: datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/shared/run_report.py
+++ b/shared/run_report.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
+import sys
+import time
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Any
@@ -17,6 +20,11 @@ logger = get_logger(__name__)
 
 STATUS_FILE = "server/status.json"
 HISTORY_DAYS = 7
+_LOCK_TIMEOUT_SECS = 10
+
+_HAS_FCNTL = sys.platform != "win32"
+if _HAS_FCNTL:
+    import fcntl
 
 
 @dataclass
@@ -104,34 +112,80 @@ def build_report(environment: str = "") -> RunReport:
     return report
 
 
+def _acquire_status_lock() -> int | None:
+    """Serialize status-file writers across the email and web_update processes.
+
+    Returns a locked file descriptor, or None if locking is unavailable
+    (Windows) or the lock could not be acquired within the timeout. On
+    timeout we proceed unlocked: losing a concurrent writer's entry is
+    bad, but silently dropping this report is worse — a lost email-run
+    entry would make retry_check re-send the email.
+    """
+    if not _HAS_FCNTL:
+        return None
+    fd = os.open(STATUS_FILE + ".lock", os.O_CREAT | os.O_WRONLY)
+    deadline = time.monotonic() + _LOCK_TIMEOUT_SECS
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except BlockingIOError:
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Status lock not acquired within %ds; writing anyway",
+                    _LOCK_TIMEOUT_SECS,
+                )
+                os.close(fd)
+                return None
+            time.sleep(0.1)
+
+
+def _release_status_lock(fd: int | None) -> None:
+    """Release the status-file lock acquired by _acquire_status_lock."""
+    if fd is None:
+        return
+    with contextlib.suppress(OSError):
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
 def upload_status_report(report: RunReport) -> None:
     """Write the run report to a rolling status file and upload via FTP.
 
     Maintains a local JSON file with the last HISTORY_DAYS days of runs.
-    Both cron jobs (email + web_update) contribute to the same history.
+    Both cron jobs (email + web_update) contribute to the same history,
+    so the read-modify-write is guarded by an flock and the file is
+    replaced atomically — a concurrent writer can never clobber an entry
+    or leave a half-written file for readers like retry_check.
     """
-    # Load existing history from local file
-    runs: list[dict] = []
-    if os.path.exists(STATUS_FILE):
-        try:
-            with open(STATUS_FILE, encoding="utf-8") as f:
-                data = json.load(f)
-            runs = data.get("runs", [])
-        except (json.JSONDecodeError, OSError):
-            runs = []
-
-    # Append current run
-    runs.append(report.to_dict())
-
-    # Trim entries older than HISTORY_DAYS
-    cutoff = (now_mountain() - timedelta(days=HISTORY_DAYS)).isoformat()
-    runs = [r for r in runs if r.get("end_time", "") >= cutoff]
-
-    # Write and upload
-    status_data = {"runs": runs}
     os.makedirs(os.path.dirname(STATUS_FILE) or ".", exist_ok=True)
-    with open(STATUS_FILE, "w", encoding="utf-8") as f:
-        json.dump(status_data, f, indent=2, default=str)
+    lock_fd = _acquire_status_lock()
+    try:
+        # Load existing history from local file
+        runs: list[dict] = []
+        if os.path.exists(STATUS_FILE):
+            try:
+                with open(STATUS_FILE, encoding="utf-8") as f:
+                    data = json.load(f)
+                runs = data.get("runs", [])
+            except (json.JSONDecodeError, OSError):
+                runs = []
+
+        # Append current run
+        runs.append(report.to_dict())
+
+        # Trim entries older than HISTORY_DAYS
+        cutoff = (now_mountain() - timedelta(days=HISTORY_DAYS)).isoformat()
+        runs = [r for r in runs if r.get("end_time", "") >= cutoff]
+
+        # Atomic replace so readers never see a partial file
+        status_data = {"runs": runs}
+        tmp_file = STATUS_FILE + ".tmp"
+        with open(tmp_file, "w", encoding="utf-8") as f:
+            json.dump(status_data, f, indent=2, default=str)
+        os.replace(tmp_file, STATUS_FILE)
+    finally:
+        _release_status_lock(lock_fd)
 
     # status.json is served from the server/ directory via the public API endpoint
     logger.info("Status report written (%d runs in history)", len(runs))

--- a/shared/run_report.py
+++ b/shared/run_report.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
 from typing import Any
@@ -189,3 +190,36 @@ def upload_status_report(report: RunReport) -> None:
 
     # status.json is served from the server/ directory via the public API endpoint
     logger.info("Status report written (%d runs in history)", len(runs))
+
+
+def complete_run(
+    environment: str,
+    *,
+    failed: bool = False,
+    decorate: Callable[[RunReport], None] | None = None,
+) -> RunReport:
+    """Build, finalize, and persist the run report at the end of a run.
+
+    Shared teardown for both entry points (main.py and
+    generate_and_upload.py). ``decorate`` mutates the report with
+    run-specific fields (subscriber count, email delivery, canary) before
+    the status is finalized. The report is only written to disk in
+    production.
+    """
+    report = build_report(environment=environment)
+    if decorate:
+        decorate(report)
+    if failed:
+        report.overall_status = "failure"
+    report.finalize_status()
+    # Log status before re-snapshotting so the line is captured in log_lines
+    logger.info("Run complete: %s", report.overall_status)
+    capture = get_log_capture()
+    if capture:
+        report.log_lines = list(capture.buffer)
+    if environment == "production":
+        try:
+            upload_status_report(report)
+        except Exception:
+            logger.exception("Failed to upload status report")
+    return report

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -105,6 +105,17 @@ class Settings:
         return cls(**kwargs)
 
 
+def required_setting_names() -> list[str]:
+    """Names of ``Settings`` fields with no default — required at startup.
+
+    Single source of truth for startup validation, so the required list
+    can never drift from the dataclass definition.
+    """
+    return [
+        f.name for f in dataclasses.fields(Settings) if f.default is dataclasses.MISSING
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Singleton access
 # ---------------------------------------------------------------------------

--- a/test/test_generate_and_upload.py
+++ b/test/test_generate_and_upload.py
@@ -457,6 +457,39 @@ def test_gen_data_none_values_replaced(mock_all_data_sources, monkeypatch):
 # ============================================================================
 
 
+class TestModuleRegistryCachingContract:
+    """Each module's caching behavior is deliberate — lock it in.
+
+    Date-deterministic modules use LKG as a primary cache only (no failure
+    fallback), gnpc_events has no LKG fallback, and the remaining dynamic
+    modules fall back to LKG on failure.
+    """
+
+    def test_caching_flags_match_intended_behavior(self):
+        expected_fallback = {
+            "weather": False,  # special-cased after the pool drains
+            "trails": True,
+            "campgrounds": True,
+            "roads": True,
+            "hiker_biker": True,
+            "events": True,
+            "sunrise": True,
+            "notices": True,
+            "gnpc_events": False,
+            "image_otd": False,
+            "peak": False,
+            "product": False,
+        }
+        expected_deterministic = {"image_otd", "peak", "product"}
+
+        actual_fallback = {spec.name: spec.lkg_fallback for spec in gau.MODULES}
+        actual_deterministic = {
+            spec.name for spec in gau.MODULES if spec.date_deterministic
+        }
+        assert actual_fallback == expected_fallback
+        assert actual_deterministic == expected_deterministic
+
+
 class TestLKGSave:
     """Verify that successful module data is saved to LKG."""
 
@@ -593,6 +626,77 @@ class TestLKGFallback:
         assert result["sunrise_still"] == "s"
         assert result["sunrise_str"] == "d"
 
+    def test_lkg_fallback_returns_dataclass_not_json_string(self, monkeypatch):
+        """LKG fallback must return usable dataclasses, not raw JSON text.
+
+        Templates access attributes like trails.closures — a JSON string
+        would silently render as an empty section.
+        """
+        self._setup_all_mocks(monkeypatch)
+        gau.gen_data()  # Populate LKG
+
+        monkeypatch.setattr(
+            gau,
+            "get_closed_trails",
+            lambda: (_ for _ in ()).throw(ConnectionError("down")),
+        )
+        result, _ = gau.gen_data()
+        assert isinstance(result["trails"], TrailsResult)
+        assert result["trails"].closures == ["trails"]
+
+    def test_weather_lkg_fallback_returns_weather_result(self, monkeypatch):
+        """Weather fallback reconstructs WeatherResult with nested fields."""
+        self._setup_all_mocks(monkeypatch)
+        gau.gen_data()  # Populate LKG with weather
+
+        monkeypatch.setattr(
+            gau,
+            "weather_data",
+            lambda: (_ for _ in ()).throw(ConnectionError("down")),
+        )
+        result, _ = gau.gen_data()
+        weather = result["weather"]
+        assert isinstance(weather, WeatherResult)
+        assert weather.daylight_message == "Daylight info"
+        assert weather.forecasts == [("West Glacier", 75, 30, "Partly cloudy")]
+
+    def test_events_lkg_fallback_reconstructs_events(self, monkeypatch):
+        """Events fallback rebuilds Event objects (sortable is dropped)."""
+        from datetime import datetime
+
+        from shared.data_types import Event
+
+        self._setup_all_mocks(monkeypatch)
+        monkeypatch.setattr(
+            gau,
+            "events_today",
+            lambda: EventsResult(
+                events=[
+                    Event(
+                        start_time="8:30 am",
+                        end_time="10 am",
+                        name="Creekside Stroll",
+                        location="Apgar VC",
+                        link="https://nps.gov/event/1",
+                        sortable=datetime(2024, 5, 1, 8, 30),
+                    )
+                ]
+            ),
+        )
+        gau.gen_data()  # Populate LKG
+
+        monkeypatch.setattr(
+            gau,
+            "events_today",
+            lambda: (_ for _ in ()).throw(ConnectionError("down")),
+        )
+        result, _ = gau.gen_data()
+        events = result["events"]
+        assert isinstance(events, EventsResult)
+        assert len(events.events) == 1
+        assert events.events[0].name == "Creekside Stroll"
+        assert events.events[0].sortable is None
+
 
 class TestLKGDateDeterministic:
     """Verify date-deterministic modules use LKG as primary cache."""
@@ -657,6 +761,106 @@ class TestLKGDateDeterministic:
 
         result, _ = gau.gen_data()
         assert result["peak"] == "pk"  # From the mocked peak function
+
+
+class TestHealthCheck:
+    """Tests for the run_health_check() deploy gate."""
+
+    def test_health_check_passes(self, mock_all_data_sources, monkeypatch):
+        monkeypatch.setattr(gau, "FTPSession", MockFTPSession)
+        assert gau.run_health_check() == 0
+
+    def test_health_check_propagates_gen_data_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            gau, "gen_data", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+        with pytest.raises(RuntimeError):
+            gau.run_health_check()
+
+    def test_health_check_propagates_ftp_failure(
+        self, mock_all_data_sources, monkeypatch
+    ):
+        class FailingFTP:
+            def __enter__(self):
+                raise ConnectionError("ftp down")
+
+            def __exit__(self, *args):
+                return False
+
+        monkeypatch.setattr(gau, "FTPSession", FailingFTP)
+        with pytest.raises(ConnectionError):
+            gau.run_health_check()
+
+
+class TestMainCLI:
+    """Tests for the main() CLI entry point."""
+
+    def _patch_common(self, monkeypatch, environment):
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            gau, "get_settings", lambda: SimpleNamespace(ENVIRONMENT=environment)
+        )
+        monkeypatch.setattr(gau, "setup_logging", lambda: None)
+
+    def test_check_flag_runs_health_check_only(self, monkeypatch):
+        self._patch_common(monkeypatch, "development")
+        calls = []
+        monkeypatch.setattr(gau, "run_health_check", lambda: calls.append("check") or 0)
+        monkeypatch.setattr(gau, "gen_data", lambda: calls.append("gen_data"))
+        monkeypatch.setattr(gau, "serve_api", lambda **kw: calls.append("serve_api"))
+
+        assert gau.main(["--check"]) == 0
+        assert calls == ["check"]
+
+    def test_development_runs_gen_data_not_serve_api(self, monkeypatch):
+        self._patch_common(monkeypatch, "development")
+        calls = []
+        monkeypatch.setattr(
+            gau, "gen_data", lambda: calls.append("gen_data") or ({}, [])
+        )
+        monkeypatch.setattr(gau, "serve_api", lambda **kw: calls.append("serve_api"))
+
+        assert gau.main([]) == 0
+        assert calls == ["gen_data"]
+
+    def test_production_runs_serve_api(self, monkeypatch):
+        self._patch_common(monkeypatch, "production")
+        calls = []
+        monkeypatch.setattr(gau, "serve_api", lambda **kw: calls.append("serve_api"))
+        monkeypatch.setattr(
+            gau, "complete_run", lambda env, **kw: calls.append("report")
+        )
+
+        assert gau.main([]) == 0
+        assert calls == ["serve_api", "report"]
+
+    def test_failure_is_caught_and_reported(self, monkeypatch):
+        self._patch_common(monkeypatch, "production")
+        reported = {}
+        monkeypatch.setattr(
+            gau,
+            "serve_api",
+            lambda **kw: (_ for _ in ()).throw(RuntimeError("upload died")),
+        )
+        monkeypatch.setattr(
+            gau,
+            "complete_run",
+            lambda env, failed=False, **kw: reported.update(env=env, failed=failed),
+        )
+
+        # Exception is caught; the failure is recorded in the run report
+        assert gau.main([]) == 0
+        assert reported == {"env": "production", "failed": True}
+
+    def test_force_flag_clears_cache(self, monkeypatch):
+        self._patch_common(monkeypatch, "development")
+        calls = []
+        monkeypatch.setattr(gau, "clear_cache", lambda: calls.append("clear"))
+        monkeypatch.setattr(gau, "gen_data", lambda: ({}, []))
+
+        assert gau.main(["--force"]) == 0
+        assert "clear" in calls
 
 
 class TestClearCache:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,4 +1,14 @@
 import main
+from shared.data_types import RoadsResult, TrailsResult, WeatherResult
+
+
+def make_healthy_data():
+    """Minimal gen_data output that passes the email content check."""
+    return {
+        "weather": WeatherResult(daylight_message="Sunrise is at 6:14am."),
+        "roads": RoadsResult(no_closures_message="No closures today!"),
+        "trails": TrailsResult(closures=["Highline: snow"]),
+    }
 
 
 def _patch_main(monkeypatch, calls):
@@ -15,7 +25,11 @@ def _patch_main(monkeypatch, calls):
         "get_subs",
         lambda tag: calls.append(f"get_subs:{tag}") or ["test@example.com"],
     )
-    monkeypatch.setattr(main, "serve_api", lambda **kw: calls.append("serve_api"))
+    monkeypatch.setattr(
+        main,
+        "serve_api",
+        lambda **kw: calls.append("serve_api") or make_healthy_data(),
+    )
     monkeypatch.setattr(main, "sleep", lambda x: calls.append(f"sleep:{x}"))
     monkeypatch.setattr(
         main,
@@ -135,6 +149,53 @@ def test_main_catches_email_delivery_exception(monkeypatch):
     main.main(test=True)
     # serve_api should have completed
     assert "serve_api" in calls
+
+
+def test_main_skips_email_when_content_hollow(monkeypatch):
+    """All core sections empty → email must NOT be sent (hollow email)."""
+    calls = []
+    _patch_main(monkeypatch, calls)
+    monkeypatch.setattr(
+        main,
+        "serve_api",
+        lambda **kw: {
+            "weather": WeatherResult(),
+            "roads": RoadsResult(),
+            "trails": TrailsResult(),
+        },
+    )
+
+    # Should not raise — the gate's exception is caught and logged
+    main.main(test=True)
+    assert not any("bulk_workflow_trigger" in c for c in calls)
+
+
+def test_email_content_ok_accepts_any_core_section():
+    assert main.email_content_ok(
+        {"weather": WeatherResult(daylight_message="sunrise at 6")}
+    )
+    assert main.email_content_ok({"roads": RoadsResult(closures=["GTSR closed"])})
+    assert main.email_content_ok(
+        {"trails": TrailsResult(no_closures_message="No closures!")}
+    )
+
+
+def test_email_content_ok_rejects_all_empty():
+    assert not main.email_content_ok(
+        {
+            "weather": WeatherResult(),
+            "roads": RoadsResult(),
+            "trails": TrailsResult(),
+        }
+    )
+    # Error messages alone are not real content
+    assert not main.email_content_ok(
+        {
+            "weather": WeatherResult(),
+            "roads": RoadsResult(error_message="Roads page is down"),
+            "trails": TrailsResult(error_message="Trails page is down"),
+        }
+    )
 
 
 def test_main_fails_when_no_subscribers(monkeypatch):

--- a/test/test_retry_check.py
+++ b/test/test_retry_check.py
@@ -78,6 +78,75 @@ def test_wrong_status_returns_false(tmp_path, monkeypatch):
     assert retry_check.has_successful_email_today() is False
 
 
+def test_partial_run_with_emails_sent_returns_true(tmp_path, monkeypatch):
+    """A partial run (module failed) that still sent emails must not retrigger."""
+    monkeypatch.setattr(retry_check, "STATUS_FILE", tmp_path / "status.json")
+    _write_status(
+        tmp_path,
+        [
+            {
+                "run_type": "email",
+                "overall_status": "partial",
+                "start_time": f"{_today()}T07:30:00",
+                "email_delivery": {"sent": 2500, "failed": 0},
+                "errors": ["weather: ConnectionError"],
+            }
+        ],
+    )
+    assert retry_check.has_successful_email_today() is True
+
+
+def test_failure_run_with_emails_sent_returns_true(tmp_path, monkeypatch):
+    """Even a run marked failure (e.g. canary raised) counts if emails went out."""
+    monkeypatch.setattr(retry_check, "STATUS_FILE", tmp_path / "status.json")
+    _write_status(
+        tmp_path,
+        [
+            {
+                "run_type": "email",
+                "overall_status": "failure",
+                "start_time": f"{_today()}T07:30:00",
+                "email_delivery": {"sent": 2500, "failed": 0},
+            }
+        ],
+    )
+    assert retry_check.has_successful_email_today() is True
+
+
+def test_partial_run_with_no_emails_sent_returns_false(tmp_path, monkeypatch):
+    """A run that never delivered anything should still trigger a retry."""
+    monkeypatch.setattr(retry_check, "STATUS_FILE", tmp_path / "status.json")
+    _write_status(
+        tmp_path,
+        [
+            {
+                "run_type": "email",
+                "overall_status": "failure",
+                "start_time": f"{_today()}T07:30:00",
+                "email_delivery": {"sent": 0, "failed": 0},
+            }
+        ],
+    )
+    assert retry_check.has_successful_email_today() is False
+
+
+def test_partial_web_update_run_does_not_count(tmp_path, monkeypatch):
+    """web_update runs never block an email retry, even with delivery data."""
+    monkeypatch.setattr(retry_check, "STATUS_FILE", tmp_path / "status.json")
+    _write_status(
+        tmp_path,
+        [
+            {
+                "run_type": "web_update",
+                "overall_status": "partial",
+                "start_time": f"{_today()}T07:30:00",
+                "email_delivery": {"sent": 5, "failed": 0},
+            }
+        ],
+    )
+    assert retry_check.has_successful_email_today() is False
+
+
 def test_wrong_date_returns_false(tmp_path, monkeypatch):
     monkeypatch.setattr(retry_check, "STATUS_FILE", tmp_path / "status.json")
     _write_status(

--- a/test/test_run_report.py
+++ b/test/test_run_report.py
@@ -15,6 +15,7 @@ from shared.run_context import start_run
 from shared.run_report import (
     RunReport,
     build_report,
+    complete_run,
     upload_status_report,
 )
 from shared.timing import ModuleResult, get_timing
@@ -462,3 +463,40 @@ class TestUploadStatusReport:
             data = json.load(f)
         run_ids = {r["run_id"] for r in data["runs"]}
         assert len(run_ids) == 2 * n_per_thread
+
+
+class TestCompleteRun:
+    """Tests for the shared complete_run teardown helper."""
+
+    def test_returns_finalized_report(self):
+        start_run("web_update")
+        report = complete_run("development")
+        assert report.overall_status == "success"
+
+    def test_failed_flag_forces_failure(self):
+        start_run("web_update")
+        report = complete_run("development", failed=True)
+        assert report.overall_status == "failure"
+
+    def test_decorate_runs_before_finalize(self):
+        start_run("email")
+
+        def decorate(report):
+            report.subscriber_count = 42
+            report.email_delivery = {"sent": 40, "failed": 2}
+
+        report = complete_run("development", decorate=decorate)
+        assert report.subscriber_count == 42
+        # finalize_status saw the delivery data decorate added
+        assert report.overall_status == "partial"
+
+    def test_writes_status_file_only_in_production(self, tmp_path, monkeypatch):
+        status_file = str(tmp_path / "status.json")
+        monkeypatch.setattr("shared.run_report.STATUS_FILE", status_file)
+
+        start_run("web_update")
+        complete_run("development")
+        assert not os.path.exists(status_file)
+
+        complete_run("production")
+        assert os.path.exists(status_file)

--- a/test/test_run_report.py
+++ b/test/test_run_report.py
@@ -3,7 +3,11 @@
 import json
 import logging
 import os
+import sys
+import threading
 from datetime import timedelta
+
+import pytest
 
 from shared.datetime_utils import now_mountain
 from shared.logging_config import get_logger, setup_logging
@@ -14,6 +18,10 @@ from shared.run_report import (
     upload_status_report,
 )
 from shared.timing import ModuleResult, get_timing
+
+_unix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="File locking requires Unix"
+)
 
 
 class TestRunReport:
@@ -383,3 +391,74 @@ class TestUploadStatusReport:
             data = json.load(f)
         assert len(data["runs"]) == 1
         assert data["runs"][0]["run_id"] == "fresh"
+
+    def test_no_tmp_file_left_behind(self, tmp_path, monkeypatch):
+        """The atomic-write temp file must be renamed away."""
+        status_file = str(tmp_path / "status.json")
+        monkeypatch.setattr("shared.run_report.STATUS_FILE", status_file)
+
+        report = RunReport(
+            run_id="r1", run_type="email", end_time=now_mountain().isoformat()
+        )
+        upload_status_report(report)
+
+        assert not os.path.exists(status_file + ".tmp")
+
+    @_unix_only
+    def test_lock_released_after_write(self, tmp_path, monkeypatch):
+        """The status lock must be free once upload_status_report returns."""
+        import fcntl
+
+        status_file = str(tmp_path / "status.json")
+        monkeypatch.setattr("shared.run_report.STATUS_FILE", status_file)
+
+        report = RunReport(
+            run_id="r1", run_type="email", end_time=now_mountain().isoformat()
+        )
+        upload_status_report(report)
+
+        # We can immediately take the lock ourselves without blocking
+        fd = os.open(status_file + ".lock", os.O_CREAT | os.O_WRONLY)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)  # raises if still held
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+    @_unix_only
+    def test_concurrent_writers_do_not_lose_entries(self, tmp_path, monkeypatch):
+        """Overlapping email and web_update writers must both keep their entries.
+
+        This is the duplicate-email regression: an unlocked read-modify-write
+        let the web_update run clobber the email run's success entry, which
+        made retry_check re-send the email.
+        """
+        status_file = str(tmp_path / "status.json")
+        monkeypatch.setattr("shared.run_report.STATUS_FILE", status_file)
+
+        end_time = now_mountain().isoformat()
+        n_per_thread = 10
+
+        def write_reports(run_type):
+            for i in range(n_per_thread):
+                upload_status_report(
+                    RunReport(
+                        run_id=f"{run_type}-{i}",
+                        run_type=run_type,
+                        end_time=end_time,
+                    )
+                )
+
+        threads = [
+            threading.Thread(target=write_reports, args=("email",)),
+            threading.Thread(target=write_reports, args=("web_update",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        with open(status_file, encoding="utf-8") as f:
+            data = json.load(f)
+        run_ids = {r["run_id"] for r in data["runs"]}
+        assert len(run_ids) == 2 * n_per_thread


### PR DESCRIPTION
## Summary

Five commits, each independently test-passing and revertible:

1. **Don't re-send the daily email when a partial run already delivered** — `retry_check` only accepted `overall_status == "success"`, so a run where one module (usually weather) failed but the email went out was retried, sending subscribers a duplicate. Any email run today with `email_delivery.sent > 0` now counts as sent.
2. **Lock and atomically write `status.json`** — the email and hourly web-update crons did unlocked read-modify-writes; an overlap could clobber the email run's success entry and trigger the same duplicate send. Writers now take an `flock` and replace the file atomically.
3. **Refactor `gen_data()` into a declarative `MODULES` registry** — replaces three parallel key-map dicts and repeated branching; adding a module is one registry entry. Per-module caching behavior is unchanged and pinned by a contract test. Also fixes a latent bug where LKG fallback values came back as raw JSON strings that templates rendered as empty sections — fallbacks now deserialize into their dataclasses. The `__main__` block became a testable `main()`/`run_health_check()` pair, and both entry points share one `complete_run()` teardown.
4. **Don't send the email when every core section is empty** — same principle as gating the send on FTP: a hollow email is worse than none. Aborts before the Drip trigger if weather, roads, and trails are all empty; the hourly retry gets another attempt.
5. **Derive the required-config list from the `Settings` dataclass** and add missing return annotations.

## Testing

- 643 tests passing (26 new), ruff + ty clean, full suite verified at every commit
- End-to-end dev run of the pipeline against real APIs: all 12 modules succeeded
- LKG deserialization verified against real cached data