### PR TITLE
Add sunset timelapse email mode (--sunset)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -90,7 +90,7 @@ Tables queried:
 - Module: `drip/drip_actions.py`, `drip/subscriber_list.py`, `drip/update_subscriber.py`
 - Endpoints used:
   - `events` — Record single subscriber events
-  - `events/batches` — Bulk workflow triggers for email delivery
+  - `events/batches` — Bulk workflow triggers for email delivery (event actions: "Glacier Daily Update trigger" for the morning email, "Sunset Timelapse trigger" for the sunset email; defined in `shared/constants.py`)
   - `workflows/{campaign_id}/subscribers` — Send to campaign
   - `subscribers` — List and update subscribers
 - Authentication: Bearer token (`DRIP_TOKEN`)
@@ -134,8 +134,8 @@ Tables queried:
 - Endpoints:
   - `http://timelapse.glacierconservancy.org/daily_timelapse_data.json`
   - `http://timelapse.glacierconservancy.org/sunrise_thumbnails.json`
-- Module: `sunrise_timelapse/get_timelapse.py`
-- Purpose: Timelapse video data and thumbnail images
+- Modules: `sunrise_timelapse/get_timelapse.py`, `sunset_timelapse/get_timelapse.py`
+- Purpose: Timelapse video data and thumbnail images. Both feeds carry sunrise and sunset entries; sunset entries use ids like `{M}_{D}_{YYYY}_sunset_timelapse` (plus a rolling `latest_sunset`) and thumbnails named `{M}_{D}_{YYYY}_sunset.jpg`
 - Authentication: None
 
 ### Cache Refresh Endpoint

--- a/drip/drip_actions.py
+++ b/drip/drip_actions.py
@@ -9,7 +9,7 @@ import requests
 
 from drip.scheduled_subs import update_scheduled_subs
 from drip.subscriber_list import subscriber_list
-from shared.constants import DRIP_BATCH_SIZE
+from shared.constants import DAILY_UPDATE_EVENT_ACTION, DRIP_BATCH_SIZE
 from shared.logging_config import get_logger
 from shared.retry import retry
 from shared.settings import get_settings
@@ -56,12 +56,16 @@ def _post_drip_batch(url: str, headers: dict, data: dict) -> requests.Response |
     return requests.post(url, headers=headers, data=json.dumps(data), timeout=15)
 
 
-def bulk_workflow_trigger(sub_list: list) -> BatchResult:
+def bulk_workflow_trigger(
+    sub_list: list, event: str = DAILY_UPDATE_EVENT_ACTION
+) -> BatchResult:
     """
     Trigger a Drip bulk event batch to send at higher throughput than individual API calls.
 
     Args:
         sub_list (list): A list of subscriber emails.
+        event (str): The Drip event action to record for each subscriber.
+            Defaults to the daily update trigger.
 
     Returns:
         BatchResult: Counts of sent and failed subscribers.
@@ -75,8 +79,6 @@ def bulk_workflow_trigger(sub_list: list) -> BatchResult:
         "Content-Type": "application/vnd.api+json",
         "User-Agent": "Glacier Daily API (glacier.org)",
     }
-
-    event = "Glacier Daily Update trigger"
 
     chunks = [
         sub_list[i : i + DRIP_BATCH_SIZE]

--- a/drip/subscriber_list.py
+++ b/drip/subscriber_list.py
@@ -4,7 +4,7 @@ This module provides a function to retrieve a list of subscribers from the Drip 
 
 import requests
 
-from shared.constants import DRIP_BATCH_SIZE
+from shared.constants import DRIP_BATCH_SIZE, EMAIL_LIST_TAGS
 from shared.logging_config import get_logger
 from shared.retry import retry
 from shared.settings import get_settings
@@ -56,7 +56,7 @@ def subscriber_list(tag="Glacier Daily Update") -> list:
         subs.extend(data["subscribers"])
 
     # If we're getting a list of people to send to just grab emails, else send all of their data.
-    if tag in ["Glacier Daily Update", "Test Glacier Daily Update"]:
+    if tag in EMAIL_LIST_TAGS:
         subs = [i["email"] for i in subs]
 
     return subs

--- a/email_html/sunset_template.html
+++ b/email_html/sunset_template.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Tonight's Sunset at Glacier</title>
+    <!--[if mso]>
+    <style type="text/css">
+        body, table, td {font-family: Arial, Helvetica, sans-serif !important;}
+    </style>
+    <![endif]-->
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+
+<body style="font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background-color: #f5f5f5; margin: 0; padding: 0; color: #3e2f13; -webkit-font-smoothing: antialiased;">
+    <div style="font-size:0px;line-height:1px;mso-line-height-rule:exactly;display:none;max-width:0px;max-height:0px;opacity:0;overflow:hidden;mso-hide:all;">
+        Watch tonight's sunset over Glacier National Park - courtesy of the Glacier National Park Conservancy
+    </div>
+
+    <!-- Main Container -->
+    <table width="100%" bgcolor="#f5f5f5" cellpadding="0" cellspacing="0" border="0">
+        <tbody>
+            <tr>
+                <td align="center" style="padding: 30px 15px;">
+                    <table cellpadding="0" cellspacing="0" width="600" border="0" style="max-width: 600px; background-color: #ffffff; border-radius: 4px;">
+                        <tbody>
+                            <!-- Header -->
+                            <tr>
+                                <td style="padding: 40px 40px 0;">
+                                    <a href="http://glacier.org/" style="display: inline-block;">
+                                        <img src="https://www.dripuploads.com/uploads/image_upload/image/3049526/embeddable_9e5a933a-16c8-4a46-a560-16a94a8ea61b.png"
+                                            width="200" height="49" alt="GNPC Logo"
+                                            style="display: block; border: 0;">
+                                    </a>
+                                </td>
+                            </tr>
+
+                            <!-- Title Header -->
+                            <tr>
+                                <td style="padding: 30px 40px 10px;">
+                                    <p style="font-size: 36px; font-weight: 300; color: #3e2f13; margin: 0 0 8px; line-height: 1.1;">
+                                        Tonight's Sunset at Glacier
+                                    </p>
+                                    <p style="font-size: 11px; text-transform: uppercase; letter-spacing: 3px; color: #a85900; margin: 0; font-weight: 600;">
+                                        GLACIER NATIONAL PARK TIMELAPSE
+                                    </p>
+                                </td>
+                            </tr>
+
+                            {% if my.daily_update.sunset_vid != blank and my.daily_update.sunset_still != blank %}
+                            <!-- Sunset Timelapse -->
+                            <tr>
+                                <td style="padding: 30px 40px;">
+                                    <a href="{{ my.daily_update.sunset_vid }}" style="display: block;">
+                                        <img src="{{ my.daily_update.sunset_still }}"
+                                            width="520" alt="Tonight's sunset at Glacier National Park"
+                                            style="display: block; margin: 0 0 15px; border: 0; border-radius: 4px; width: 100%; max-width: 520px;">
+                                    </a>
+                                    <p style="font-size: 14px; color: #666666; margin: 0;">
+                                        <a href="{{ my.daily_update.sunset_vid }}" style="color: #a85900; font-weight: 600;">Click to watch the timelapse</a> of tonight's sunset over the park.
+                                    </p>
+                                </td>
+                            </tr>
+                            {% else %}
+                            <!-- Fallback when tonight's video is unavailable -->
+                            <tr>
+                                <td style="padding: 30px 40px;">
+                                    <p style="font-size: 14px; line-height: 1.7; color: #444444; margin: 0;">
+                                        Tonight's sunset timelapse isn't available right now. You can find the latest webcam timelapses at
+                                        <a href="https://glacier.org/webcam-timelapse/" style="color: #028CA9;">glacier.org/webcam-timelapse</a>.
+                                    </p>
+                                </td>
+                            </tr>
+                            {% endif %}
+
+                            <!-- Divider -->
+                            <tr>
+                                <td style="padding: 0 40px;">
+                                    <div style="border-top: 1px solid #e0e0e0;"></div>
+                                </td>
+                            </tr>
+
+                            <!-- Footer -->
+                            <tr>
+                                <td style="padding: 30px 40px 50px;">
+                                    <p style="font-size: 14px; font-weight: 600; color: #3e2f13; margin: 0 0 10px;">
+                                        Glacier National Park Conservancy
+                                    </p>
+                                    <p style="font-size: 12px; line-height: 1.7; color: #666666; margin: 0 0 15px;">
+                                        {{ inline_postal_address }}
+                                    </p>
+                                    <p style="font-size: 12px; line-height: 1.8; color: #666666; margin: 0;">
+                                        <a href="http://glacier.org/" style="color: #6c8d3b;">glacier.org</a> ·
+                                        <a href="https://glacier.org/webcam-timelapse/" style="color: #6c8d3b;">All webcam timelapses</a>
+                                    </p>
+                                    <p style="font-size: 12px; line-height: 1.8; color: #666666; margin: 10px 0 0;">
+                                        <a href="{{ unsubscribe_url }}" style="color: #6c8d3b;">Unsubscribe from all GNPC mailings</a>
+                                    </p>
+                                    <p style="font-size: 11px; color: #999999; margin: 20px 0 0;">
+                                        Generated at: {{ my.daily_update.time_generated }}
+                                    </p>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/email_html/sunset_template.html
+++ b/email_html/sunset_template.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Tonight's Sunset at Glacier</title>
+    <title>Tonight's Glacier Sunset</title>
     <!--[if mso]>
     <style type="text/css">
         body, table, td {font-family: Arial, Helvetica, sans-serif !important;}
@@ -40,7 +40,7 @@
                             <tr>
                                 <td style="padding: 30px 40px 10px;">
                                     <p style="font-size: 36px; font-weight: 300; color: #3e2f13; margin: 0 0 8px; line-height: 1.1;">
-                                        Tonight's Sunset at Glacier
+                                        Tonight's Glacier Sunset
                                     </p>
                                     <p style="font-size: 11px; text-transform: uppercase; letter-spacing: 3px; color: #a85900; margin: 0; font-weight: 600;">
                                         GLACIER NATIONAL PARK TIMELAPSE

--- a/generate_and_upload.py
+++ b/generate_and_upload.py
@@ -50,6 +50,7 @@ from shared.run_report import complete_run
 from shared.settings import get_settings
 from shared.timing import timed
 from sunrise_timelapse.get_timelapse import process_video
+from sunset_timelapse.get_timelapse import process_sunset_video
 from trails_and_cgs.frontcountry_cgs import get_campground_status
 from trails_and_cgs.trails import get_closed_trails
 from weather.weather import weather_data
@@ -107,6 +108,14 @@ MODULES: tuple[ModuleSpec, ...] = (
         "sunrise",
         process_video,
         ("sunrise_vid", "sunrise_still", "sunrise_str"),
+        lambda: ("", "", ""),
+    ),
+    # Sunset fields are blank until the timelapse system publishes
+    # tonight's video (evenings) — template guards hide the section
+    ModuleSpec(
+        "sunset",
+        process_sunset_video,
+        ("sunset_vid", "sunset_still", "sunset_str"),
         lambda: ("", "", ""),
     ),
     ModuleSpec("notices", get_notices, ("notices",), NoticesResult),

--- a/main.py
+++ b/main.py
@@ -12,12 +12,14 @@ from drip.canary_check import CanaryResult, check_canary_delivery
 from drip.drip_actions import bulk_workflow_trigger, get_subs
 from generate_and_upload import serve_api
 from shared.config_validation import validate_config
+from shared.constants import SUNSET_TIMELAPSE_EVENT_ACTION, SUNSET_TIMELAPSE_TAG
 from shared.lock import acquire_lock, release_lock
 from shared.logging_config import get_logger, setup_logging
 from shared.run_context import start_run
 from shared.run_report import RunReport, complete_run
 from shared.settings import get_settings
 from sunrise_timelapse.sleep_to_sunrise import sleep_time as sleep_to_sunrise
+from sunset_timelapse.get_timelapse import TONIGHT_DESCRIPTOR
 
 logger = get_logger(__name__)
 
@@ -42,6 +44,114 @@ def email_content_ok(data: dict) -> bool:
     return bool(
         getattr(trails, "closures", []) or getattr(trails, "no_closures_message", "")
     )
+
+
+def sunset_content_ok(data: dict) -> bool:
+    """Check the generated data contains tonight's sunset timelapse.
+
+    The sunset email is today-or-nothing: it exists to say "here is
+    tonight's sunset", so sending a stale video is worse than not
+    sending. The fields are blank when the timelapse system hasn't
+    published today's entry, and the descriptor is "Latest" when only
+    the stale latest_sunset fallback was available (kept for the web
+    version / email.json).
+    """
+    return bool(
+        data.get("sunset_vid")
+        and data.get("sunset_still")
+        and data.get("sunset_str") == TONIGHT_DESCRIPTOR
+    )
+
+
+def sunset_main(
+    tag: str = SUNSET_TIMELAPSE_TAG, test: bool = False, force: bool = False
+) -> None:
+    """
+    Send the evening sunset timelapse email.
+
+    Invoked via ``main.py --sunset`` by the timelapse system after it
+    finishes uploading the sunset timelapse. Regenerates and uploads
+    email.json (so my.daily_update.sunset_vid / sunset_still are fresh),
+    then fires the sunset Drip workflow trigger — unless tonight's video
+    is missing, in which case no email is sent.
+
+    The canary delivery check is skipped: it isn't email-type-aware
+    (any same-day email from the sender would verify), so it can't
+    distinguish the sunset email from the morning daily update.
+
+    Args:
+        tag (str): Tag to filter subscribers. Defaults to 'Sunset Timelapse'.
+        test (bool): Whether running in test mode (skips sleep delays).
+        force (bool): Clear cached data and re-fetch everything fresh.
+    """
+    settings = get_settings()  # Load email.env so ENVIRONMENT is available
+    run = start_run("sunset_email")
+    setup_logging()
+    logger.info("Starting run %s (type=%s)", run.run_id, run.run_type)
+    validate_config()
+
+    lock_fd = acquire_lock()
+    if lock_fd is None:
+        logger.error("Another instance is already running. Exiting.")
+        return
+
+    subscribers: list[str] = []
+    try:
+        batch_result = None
+        run_error: str | None = None
+        api_complete = False
+        try:
+            # Retrieve subscribers from Drip.
+            subscribers = get_subs(tag)
+            logger.info("Sunset subscribers found: %d", len(subscribers))
+
+            if not subscribers:
+                raise RuntimeError("No subscribers retrieved — Drip API may be down")
+
+            # Regenerate data and upload email.json to the website.
+            data = serve_api(force=force)
+            api_complete = True
+
+            if not sunset_content_ok(data):
+                raise RuntimeError(
+                    "Sunset content check failed: tonight's sunset timelapse "
+                    "is not available (the timelapse upload presumably "
+                    "failed) — not sending the sunset email"
+                )
+
+            # Allow time for FTP-uploaded timelapse assets to propagate.
+            _TIMELAPSE_PROPAGATION_WAIT = 0 if test else 10
+            sleep(_TIMELAPSE_PROPAGATION_WAIT)
+
+            # Send the email to each subscriber using Drip API.
+            batch_result = bulk_workflow_trigger(
+                subscribers, event=SUNSET_TIMELAPSE_EVENT_ACTION
+            )
+        except Exception:
+            phase = "data generation/upload" if not api_complete else "email delivery"
+            logger.exception("%s failed", phase)
+            run_error = f"{phase} raised an exception (see logs)"
+        finally:
+
+            def _decorate(report: RunReport) -> None:
+                report.subscriber_count = len(subscribers)
+                if batch_result:
+                    report.email_delivery = {
+                        "sent": batch_result.sent,
+                        "failed": batch_result.failed,
+                    }
+                if run_error:
+                    report.errors.append(run_error)
+                    if not batch_result:
+                        report.email_delivery = {"sent": 0, "failed": 0}
+
+            complete_run(
+                settings.ENVIRONMENT,
+                failed=bool(run_error),
+                decorate=_decorate,
+            )
+    finally:
+        release_lock(lock_fd)
 
 
 def main(
@@ -148,7 +258,19 @@ if __name__ == "__main__":  # pragma: no cover
         action="store_true",
         help="Clear cached data and re-fetch everything fresh",
     )
+    parser.add_argument(
+        "--sunset",
+        action="store_true",
+        help="Send the sunset timelapse email instead of the daily update "
+        "(invoked by the timelapse system after the sunset video uploads)",
+    )
     args = parser.parse_args()
 
-    test_mode = args.tag != "Glacier Daily Update"
-    main(args.tag, test=test_mode, force=args.force)
+    if args.sunset:
+        # --tag still selects the daily default here; swap in the sunset tag
+        # unless the caller overrode it (e.g. 'Test Sunset Timelapse')
+        tag = SUNSET_TIMELAPSE_TAG if args.tag == "Glacier Daily Update" else args.tag
+        sunset_main(tag, test=tag != SUNSET_TIMELAPSE_TAG, force=args.force)
+    else:
+        test_mode = args.tag != "Glacier Daily Update"
+        main(args.tag, test=test_mode, force=args.force)

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ An automated system that generates and distributes daily email updates about con
 - Trail and road status tracking
 - Daily featured peak with satellite imagery
 - Sunrise timelapse videos
+- Evening sunset timelapse email
 - Ranger-led activity schedules
 - Featured product and image of the day
 - Aurora forecast
@@ -48,6 +49,13 @@ uv run python main.py --tag "Test Glacier Daily Update"
 
 # Force re-fetch all data (clear cache)
 uv run python main.py --force
+
+# Send the sunset timelapse email (invoked by the timelapse system each
+# evening after it uploads the sunset video — not run by cron here)
+uv run python main.py --sunset
+
+# Sunset test mode (test subscribers only)
+uv run python main.py --sunset --tag "Test Sunset Timelapse"
 
 # Generate and upload data only (no email sending)
 uv run python generate_and_upload.py
@@ -146,6 +154,7 @@ uv run python -W ignore -m peak.peak
 
 **Entry Points:**
 - `main.py` - Full pipeline: data collection, FTP upload, email delivery
+- `main.py --sunset` - Sunset email pipeline: regenerates/uploads email.json and fires the "Sunset Timelapse trigger" Drip event to subscribers tagged "Sunset Timelapse". Invoked by the separate timelapse system each evening after the sunset video uploads. Today-or-nothing: if tonight's sunset video isn't in the timelapse feed, no email is sent. Tag and event names live in `shared/constants.py`; the Drip workflow email uses `email_html/sunset_template.html`
 - `generate_and_upload.py` - Data collection and FTP upload only (used for web version updates)
 - `retry_check.py` - Cron-driven retry checker: retriggers `main.py` if today's email hasn't gone out (a partial run that already delivered emails does not retrigger)
 - `web_version.py` - Generates the web version of the daily update via Liquid-to-Jinja2 template rendering
@@ -159,6 +168,7 @@ uv run python -W ignore -m peak.peak
 - `image_otd/` - Daily image selection from Flickr
 - `product_otd/` - Featured product from Shopify
 - `sunrise_timelapse/` - Video processing and timelapse compilation
+- `sunset_timelapse/` - Tonight's sunset video/thumbnail selection for the sunset email
 - `notices/` - Administrative notices from Google Sheets
 
 **Infrastructure:**

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -8,3 +8,22 @@ WEST_GLACIER_LON = -113.991674
 
 # Drip API maximum batch/page size
 DRIP_BATCH_SIZE = 1000
+
+# Drip subscriber tags
+DAILY_UPDATE_TAG = "Glacier Daily Update"
+TEST_DAILY_UPDATE_TAG = "Test Glacier Daily Update"
+SUNSET_TIMELAPSE_TAG = "Sunset Timelapse"
+TEST_SUNSET_TIMELAPSE_TAG = "Test Sunset Timelapse"
+
+# Tags used to build send lists — subscriber_list returns bare email
+# addresses for these instead of full subscriber records
+EMAIL_LIST_TAGS = (
+    DAILY_UPDATE_TAG,
+    TEST_DAILY_UPDATE_TAG,
+    SUNSET_TIMELAPSE_TAG,
+    TEST_SUNSET_TIMELAPSE_TAG,
+)
+
+# Drip workflow-trigger event actions
+DAILY_UPDATE_EVENT_ACTION = "Glacier Daily Update trigger"
+SUNSET_TIMELAPSE_EVENT_ACTION = "Sunset Timelapse trigger"

--- a/sunrise_timelapse/get_timelapse.py
+++ b/sunrise_timelapse/get_timelapse.py
@@ -94,9 +94,11 @@ def select_video(
                 id_ = entry.get("vid_src").split("/")[-1].rsplit("_", 2)[0]
                 return id_, entry.get("url"), "Latest"
 
-        # If no latest found, return the first valid entry
-        if video_entries:
-            return video_entries[0].get("id"), video_entries[0].get("url"), "Latest"
+        # If no latest found, return the first sunrise entry
+        # (the feed also carries sunset entries)
+        for entry in video_entries:
+            if "sunrise" in entry.get("id", ""):
+                return entry.get("id"), entry.get("url"), "Latest"
 
         return None, None, None
 

--- a/sunset_timelapse/__init__.py
+++ b/sunset_timelapse/__init__.py
@@ -1,0 +1,1 @@
+"""Sunset timelapse video selection for the evening sunset email."""

--- a/sunset_timelapse/get_timelapse.py
+++ b/sunset_timelapse/get_timelapse.py
@@ -1,0 +1,150 @@
+"""
+Select tonight's sunset timelapse video and matching thumbnail.
+
+The timelapse system publishes sunset entries into the same two JSON
+feeds the sunrise flow consumes (daily_timelapse_data.json and
+sunrise_thumbnails.json). Sunset entries use the id
+``{M}_{D}_{YYYY}_sunset_timelapse`` and thumbnails named
+``{M}_{D}_{YYYY}_sunset.jpg``, plus a rolling ``latest_sunset`` entry.
+"""
+
+from shared.datetime_utils import now_mountain
+from shared.logging_config import get_logger
+from sunrise_timelapse.get_timelapse import fetch_glacier_data
+
+logger = get_logger(__name__)
+
+# Descriptor for a sunset published today. The sunset email is
+# today-or-nothing: main.py only triggers the send when the selected
+# video carries this descriptor, while the "Latest" fallback remains
+# available to the web version / email.json.
+TONIGHT_DESCRIPTOR = "Tonight's"
+
+
+def select_sunset_video(
+    timelapse_data: list,
+) -> tuple[str | None, str | None, str | None]:
+    """
+    Select a sunset video: today's entry first, then the latest_sunset fallback.
+
+    Args:
+        timelapse_data (list): JSON data from the timelapse endpoint
+
+    Returns:
+        tuple[Optional[str], Optional[str], Optional[str]]: (video_id, video_url, descriptor)
+    """
+    if not timelapse_data:
+        return None, None, None
+
+    try:
+        today = now_mountain()
+        today_id = f"{today.month}_{today.day}_{today.year}_sunset_timelapse"
+
+        # Skip the first entry which is just the date
+        video_entries = [
+            entry
+            for entry in timelapse_data
+            if isinstance(entry, dict) and "id" in entry
+        ]
+
+        # First, look for tonight's video
+        for entry in video_entries:
+            if entry.get("id") == today_id:
+                return entry.get("id"), entry.get("url"), TONIGHT_DESCRIPTOR
+
+        # Fallback to the rolling latest_sunset entry. Unlike the sunrise
+        # flow there is no "first valid entry" fallback — the feed mixes
+        # sunrise and sunset entries, so an arbitrary entry could be a
+        # sunrise video.
+        for entry in video_entries:
+            if entry.get("id") == "latest_sunset":
+                id_ = entry.get("vid_src").split("/")[-1].rsplit("_", 2)[0]
+                return id_, entry.get("url"), "Latest"
+
+        return None, None, None
+
+    except Exception as e:
+        logger.error("Error selecting sunset video: %s", e)
+        return None, None, None
+
+
+def find_matching_sunset_thumbnail(video_id: str, thumbnail_data: list) -> str | None:
+    """
+    Find the thumbnail that matches the selected sunset video.
+
+    Args:
+        video_id (str): ID of the selected video
+        thumbnail_data (list): JSON data from the thumbnail endpoint
+
+    Returns:
+        Optional[str]: Full URL to the thumbnail image
+    """
+    if not video_id or not thumbnail_data:
+        return None
+
+    try:
+        # Extract date pattern from video_id (e.g., "8_20_2025" from "8_20_2025_sunset_timelapse")
+        video_date_part = video_id.replace("_sunset_timelapse", "")
+        expected_thumbnail = f"{video_date_part}_sunset.jpg"
+
+        # Skip the first entry which is just the date
+        thumbnail_entries = [
+            entry
+            for entry in thumbnail_data
+            if isinstance(entry, dict) and "path" in entry
+        ]
+
+        for entry in thumbnail_entries:
+            thumbnail_path = entry.get("path", "")
+            if expected_thumbnail in thumbnail_path:
+                return f"https://glacier.org{thumbnail_path}"
+
+        return None
+
+    except Exception as e:
+        logger.error("Error finding matching sunset thumbnail: %s", e)
+        return None
+
+
+def process_sunset_video() -> tuple[str, str, str]:
+    """
+    Fetch remote timelapse data and select the sunset video and thumbnail.
+
+    Returns:
+        tuple[str, str, str]: (video_url, thumbnail_url, descriptor_string)
+        video_url is the webcam-timelapse page URL (not the raw mp4) and
+        thumbnail_url is an absolute https://glacier.org URL.
+        Returns ("", "", "") if any error occurs.
+    """
+    try:
+        # Fetch remote data
+        timelapse_data = fetch_glacier_data("timelapse")
+        thumbnail_data = fetch_glacier_data("thumbnails")
+
+        if not timelapse_data or not thumbnail_data:
+            logger.warning("Failed to fetch remote sunset timelapse data")
+            return "", "", ""
+
+        # Select video based on today's date first, then latest_sunset
+        video_id, video_url, descriptor = select_sunset_video(timelapse_data)
+
+        if not video_id or not video_url:
+            logger.warning("No suitable sunset video found")
+            return "", "", ""
+
+        # Find matching thumbnail
+        thumbnail_url = find_matching_sunset_thumbnail(video_id, thumbnail_data)
+
+        if not thumbnail_url:
+            logger.warning("No matching thumbnail found for sunset video %s", video_id)
+            return "", "", ""
+
+        return video_url, thumbnail_url, descriptor or ""
+
+    except Exception as e:
+        logger.exception("Unexpected error in process_sunset_video: %s", e)
+        return "", "", ""
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(process_sunset_video())

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -61,6 +61,10 @@ def generated_data():
             "generate_and_upload.process_video", return_value=("vid", "still", "str")
         ),
         patch(
+            "generate_and_upload.process_sunset_video",
+            return_value=("s_vid", "s_still", "s_str"),
+        ),
+        patch(
             "generate_and_upload.get_campground_status",
             return_value=CampgroundsResult(statuses=["campground status"]),
         ),
@@ -98,6 +102,9 @@ def expected_keys():
         "image_otd_link",
         "sunrise_vid",
         "sunrise_still",
+        "sunset_vid",
+        "sunset_still",
+        "sunset_str",
     }
 
 

--- a/test/test_drip.py
+++ b/test/test_drip.py
@@ -123,6 +123,63 @@ def test_bulk_workflow_trigger(monkeypatch, mock_required_settings):
     assert "url" in called
 
 
+def test_bulk_workflow_trigger_default_event(monkeypatch, mock_required_settings):
+    """Without an event argument, the daily update trigger action is sent."""
+    import json as json_lib
+
+    captured = {}
+
+    def fake_post(url, headers, data, timeout):
+        captured["data"] = data
+
+        class R:
+            status_code = 201
+
+            def json(self):
+                return {}
+
+        return R()
+
+    monkeypatch.setattr(drip_actions, "requests", types.SimpleNamespace(post=fake_post))
+    _set_drip_env(monkeypatch)
+    drip_actions.bulk_workflow_trigger(["a@example.com"])
+    payload = json_lib.loads(captured["data"])
+    events = payload["batches"][0]["events"]
+    assert events == [
+        {"email": "a@example.com", "action": "Glacier Daily Update trigger"}
+    ]
+
+
+def test_bulk_workflow_trigger_custom_event(monkeypatch, mock_required_settings):
+    """A custom event argument (e.g. the sunset trigger) is sent to Drip."""
+    import json as json_lib
+
+    from shared.constants import SUNSET_TIMELAPSE_EVENT_ACTION
+
+    captured = {}
+
+    def fake_post(url, headers, data, timeout):
+        captured["data"] = data
+
+        class R:
+            status_code = 201
+
+            def json(self):
+                return {}
+
+        return R()
+
+    monkeypatch.setattr(drip_actions, "requests", types.SimpleNamespace(post=fake_post))
+    _set_drip_env(monkeypatch)
+    result = drip_actions.bulk_workflow_trigger(
+        ["a@example.com"], event=SUNSET_TIMELAPSE_EVENT_ACTION
+    )
+    payload = json_lib.loads(captured["data"])
+    events = payload["batches"][0]["events"]
+    assert events == [{"email": "a@example.com", "action": "Sunset Timelapse trigger"}]
+    assert result.sent == 1
+
+
 def test_bulk_workflow_trigger_chunking(monkeypatch, mock_required_settings):
     """Verify >1000 subscribers are chunked into batches of 1000."""
     post_calls = []
@@ -272,6 +329,31 @@ def test_subscriber_list_returns_full_objects(monkeypatch, mock_required_setting
     result = subscriber_list.subscriber_list(tag="Daily Start Set")
     assert isinstance(result[0], dict)
     assert result[0]["email"] == "a@example.com"
+
+
+def test_subscriber_list_sunset_tag_returns_emails(monkeypatch, mock_required_settings):
+    """Sunset send-list tags return bare email addresses, like the daily tags."""
+
+    class FakeResponse:
+        def json(self):
+            return {
+                "subscribers": [
+                    {"email": "a@example.com", "tags": ["Sunset Timelapse"]}
+                ],
+                "meta": {"total_pages": 1},
+            }
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(
+        subscriber_list,
+        "requests",
+        types.SimpleNamespace(get=lambda *a, **k: FakeResponse()),
+    )
+    _set_drip_env(monkeypatch)
+    result = subscriber_list.subscriber_list(tag="Sunset Timelapse")
+    assert result == ["a@example.com"]
 
 
 def test_subscriber_list_failure(monkeypatch, mock_required_settings):

--- a/test/test_gen_data_integration.py
+++ b/test/test_gen_data_integration.py
@@ -38,6 +38,9 @@ EXPECTED_KEYS = {
     "sunrise_vid",
     "sunrise_still",
     "sunrise_str",
+    "sunset_vid",
+    "sunset_still",
+    "sunset_str",
     "gnpc-events",
 }
 

--- a/test/test_generate_and_upload.py
+++ b/test/test_generate_and_upload.py
@@ -69,6 +69,9 @@ def mock_all_data_sources(monkeypatch):
     monkeypatch.setattr(gau, "peak", lambda **kw: ("peak", "peak_img", "peak_map"))
     monkeypatch.setattr(gau, "process_video", lambda: ("vid", "still", "descriptor"))
     monkeypatch.setattr(
+        gau, "process_sunset_video", lambda: ("s_vid", "s_still", "s_descriptor")
+    )
+    monkeypatch.setattr(
         gau,
         "get_product",
         lambda **kw: ("prod_title", "prod_img", "prod_link", "prod_desc"),
@@ -108,6 +111,9 @@ def test_gen_data_keys_present(mock_all_data_sources):
         "sunrise_vid",
         "sunrise_still",
         "sunrise_str",
+        "sunset_vid",
+        "sunset_still",
+        "sunset_str",
         "gnpc-events",
     ]
 
@@ -145,6 +151,9 @@ def test_gen_data_string_fields_are_strings(mock_all_data_sources):
         "sunrise_vid",
         "sunrise_still",
         "sunrise_str",
+        "sunset_vid",
+        "sunset_still",
+        "sunset_str",
         "weather_image",
         "peak_map",
     ]
@@ -474,6 +483,7 @@ class TestModuleRegistryCachingContract:
             "hiker_biker": True,
             "events": True,
             "sunrise": True,
+            "sunset": True,
             "notices": True,
             "gnpc_events": False,
             "image_otd": False,
@@ -530,6 +540,7 @@ class TestLKGSave:
         monkeypatch.setattr(gau, "get_image_otd", lambda **kw: ("img", "title", "link"))
         monkeypatch.setattr(gau, "peak", lambda **kw: ("pk", "pk_img", "pk_map"))
         monkeypatch.setattr(gau, "process_video", lambda: ("v", "s", "d"))
+        monkeypatch.setattr(gau, "process_sunset_video", lambda: ("sv", "ss", "sd"))
         monkeypatch.setattr(gau, "get_product", lambda **kw: ("t", "i", "l", "d"))
         monkeypatch.setattr(
             gau, "get_notices", lambda: NoticesResult(fallback_message="No notices")
@@ -574,6 +585,7 @@ class TestLKGFallback:
         monkeypatch.setattr(gau, "get_image_otd", lambda **kw: ("img", "title", "link"))
         monkeypatch.setattr(gau, "peak", lambda **kw: ("pk", "pk_img", "map"))
         monkeypatch.setattr(gau, "process_video", lambda: ("v", "s", "d"))
+        monkeypatch.setattr(gau, "process_sunset_video", lambda: ("sv", "ss", "sd"))
         monkeypatch.setattr(gau, "get_product", lambda **kw: ("t", "i", "l", "d"))
         monkeypatch.setattr(
             gau, "get_notices", lambda: NoticesResult(fallback_message="No notices")
@@ -625,6 +637,22 @@ class TestLKGFallback:
         assert result["sunrise_vid"] == "v"
         assert result["sunrise_still"] == "s"
         assert result["sunrise_str"] == "d"
+
+    def test_sunset_lkg_fallback(self, monkeypatch):
+        """Sunset tuple is reconstructed from LKG on failure."""
+        self._setup_all_mocks(monkeypatch)
+        gau.gen_data()  # Populate LKG
+
+        # Simulate sunset failure
+        monkeypatch.setattr(
+            gau,
+            "process_sunset_video",
+            lambda: (_ for _ in ()).throw(ConnectionError("down")),
+        )
+        result, _ = gau.gen_data()
+        assert result["sunset_vid"] == "sv"
+        assert result["sunset_still"] == "ss"
+        assert result["sunset_str"] == "sd"
 
     def test_lkg_fallback_returns_dataclass_not_json_string(self, monkeypatch):
         """LKG fallback must return usable dataclasses, not raw JSON text.
@@ -721,6 +749,7 @@ class TestLKGDateDeterministic:
         monkeypatch.setattr(gau, "get_image_otd", lambda **kw: ("img", "title", "link"))
         monkeypatch.setattr(gau, "peak", lambda **kw: ("pk", "pk_img", "map"))
         monkeypatch.setattr(gau, "process_video", lambda: ("v", "s", "d"))
+        monkeypatch.setattr(gau, "process_sunset_video", lambda: ("sv", "ss", "sd"))
         monkeypatch.setattr(gau, "get_product", lambda **kw: ("t", "i", "l", "d"))
         monkeypatch.setattr(
             gau, "get_notices", lambda: NoticesResult(fallback_message="No notices")

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -209,3 +209,129 @@ def test_main_fails_when_no_subscribers(monkeypatch):
     # Data generation and email sending should not have been attempted
     assert "serve_api" not in calls
     assert not any("bulk_workflow_trigger" in c for c in calls)
+
+
+# ============================================================================
+# Sunset email flow (main.py --sunset)
+# ============================================================================
+
+
+def make_sunset_data(descriptor="Tonight's", vid="vid_url", still="still_url"):
+    """Minimal serve_api output for the sunset content gate."""
+    return {
+        "sunset_vid": vid,
+        "sunset_still": still,
+        "sunset_str": descriptor,
+    }
+
+
+def _patch_sunset_main(monkeypatch, calls):
+    """Apply standard monkeypatches for sunset_main tests."""
+    monkeypatch.setattr(main, "setup_logging", lambda: None)
+    monkeypatch.setattr(main, "validate_config", lambda: None)
+    monkeypatch.setattr(main, "acquire_lock", lambda: 999)
+    monkeypatch.setattr(main, "release_lock", lambda fd: None)
+    monkeypatch.setattr(
+        main,
+        "get_subs",
+        lambda tag: calls.append(f"get_subs:{tag}") or ["test@example.com"],
+    )
+    monkeypatch.setattr(
+        main,
+        "serve_api",
+        lambda **kw: calls.append("serve_api") or make_sunset_data(),
+    )
+    monkeypatch.setattr(main, "sleep", lambda x: calls.append(f"sleep:{x}"))
+    monkeypatch.setattr(
+        main,
+        "bulk_workflow_trigger",
+        lambda subs, event=None: calls.append(f"bulk_workflow_trigger:{subs}:{event}"),
+    )
+
+
+def test_sunset_main_runs_all_steps(monkeypatch):
+    calls = []
+    _patch_sunset_main(monkeypatch, calls)
+
+    main.sunset_main(test=True)
+    assert calls == [
+        "get_subs:Sunset Timelapse",
+        "serve_api",
+        "sleep:0",
+        "bulk_workflow_trigger:['test@example.com']:Sunset Timelapse trigger",
+    ]
+
+
+def test_sunset_main_fails_when_no_subscribers(monkeypatch):
+    """When get_subs returns empty list, nothing is generated or sent."""
+    calls = []
+    _patch_sunset_main(monkeypatch, calls)
+    monkeypatch.setattr(main, "get_subs", lambda tag: [])
+
+    main.sunset_main(test=True)
+    assert "serve_api" not in calls
+    assert not any("bulk_workflow_trigger" in c for c in calls)
+
+
+def test_sunset_main_skips_email_when_video_missing(monkeypatch):
+    """Blank sunset fields (timelapse failed) → no trigger fired."""
+    calls = []
+    _patch_sunset_main(monkeypatch, calls)
+    monkeypatch.setattr(
+        main,
+        "serve_api",
+        lambda **kw: (
+            calls.append("serve_api")
+            or make_sunset_data(descriptor="", vid="", still="")
+        ),
+    )
+
+    # Should not raise — the gate's exception is caught and logged
+    main.sunset_main(test=True)
+    assert "serve_api" in calls
+    assert not any("bulk_workflow_trigger" in c for c in calls)
+
+
+def test_sunset_main_skips_email_when_only_stale_video(monkeypatch):
+    """A 'Latest' (stale) fallback video must not trigger the email."""
+    calls = []
+    _patch_sunset_main(monkeypatch, calls)
+    monkeypatch.setattr(
+        main,
+        "serve_api",
+        lambda **kw: calls.append("serve_api") or make_sunset_data(descriptor="Latest"),
+    )
+
+    main.sunset_main(test=True)
+    assert not any("bulk_workflow_trigger" in c for c in calls)
+
+
+def test_sunset_main_exits_when_locked(monkeypatch):
+    calls = []
+    _patch_sunset_main(monkeypatch, calls)
+    monkeypatch.setattr(main, "acquire_lock", lambda: None)
+
+    main.sunset_main(test=True)
+    assert not calls
+
+
+def test_sunset_main_catches_email_delivery_exception(monkeypatch):
+    """When bulk_workflow_trigger raises, sunset_main logs instead of propagating."""
+    calls = []
+    _patch_sunset_main(monkeypatch, calls)
+
+    def raise_on_trigger(subs, event=None):
+        raise RuntimeError("Drip API exploded")
+
+    monkeypatch.setattr(main, "bulk_workflow_trigger", raise_on_trigger)
+
+    main.sunset_main(test=True)
+    assert "serve_api" in calls
+
+
+def test_sunset_content_ok_requires_tonight_descriptor():
+    assert main.sunset_content_ok(make_sunset_data())
+    assert not main.sunset_content_ok(make_sunset_data(descriptor="Latest"))
+    assert not main.sunset_content_ok(make_sunset_data(vid=""))
+    assert not main.sunset_content_ok(make_sunset_data(still=""))
+    assert not main.sunset_content_ok({})

--- a/test/test_sunset_timelapse.py
+++ b/test/test_sunset_timelapse.py
@@ -1,0 +1,265 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from sunset_timelapse.get_timelapse import (
+    find_matching_sunset_thumbnail,
+    process_sunset_video,
+    select_sunset_video,
+)
+
+# Mock data for testing — the feed mixes sunrise and sunset entries
+MOCK_TIMELAPSE_DATA = [
+    {"date": "2025-08-20 21:19:06.770128"},
+    {
+        "id": "latest",
+        "vid_src": "/daily/sunrise_vid/8_20_2025_sunrise_timelapse.mp4",
+        "url": "https://glacier.org/webcam-timelapse/?type=daily&id=latest",
+        "title": "Latest Sunrise Timelapse",
+        "string": "Latest Sunrise",
+    },
+    {
+        "id": "latest_sunset",
+        "vid_src": "/daily/sunrise_vid/8_20_2025_sunset_timelapse.mp4",
+        "url": "https://glacier.org/webcam-timelapse/?type=daily&id=latest_sunset",
+        "title": "Latest Sunset Timelapse",
+        "string": "Latest Sunset",
+    },
+    {
+        "id": "8_20_2025_sunrise_timelapse",
+        "vid_src": "/daily/sunrise_vid/8_20_2025_sunrise_timelapse.mp4",
+        "url": "https://glacier.org/webcam-timelapse/?type=daily&id=8_20_2025_sunrise_timelapse",
+        "title": "8-20 Sunrise Timelapse",
+        "string": "8-20 Sunrise",
+    },
+    {
+        "id": "8_20_2025_sunset_timelapse",
+        "vid_src": "/daily/sunrise_vid/8_20_2025_sunset_timelapse.mp4",
+        "url": "https://glacier.org/webcam-timelapse/?type=daily&id=8_20_2025_sunset_timelapse",
+        "title": "8-20 Sunset Timelapse",
+        "string": "8-20 Sunset",
+    },
+    {
+        "id": "8_19_2025_sunset_timelapse",
+        "vid_src": "/daily/sunrise_vid/8_19_2025_sunset_timelapse.mp4",
+        "url": "https://glacier.org/webcam-timelapse/?type=daily&id=8_19_2025_sunset_timelapse",
+        "title": "8-19 Sunset Timelapse",
+        "string": "8-19 Sunset",
+    },
+]
+
+MOCK_THUMBNAIL_DATA = [
+    {"date": "2025-08-20 21:19:30.366413"},
+    {"path": "/daily/sunrise_still/8_20_2025_sunrise.jpg"},
+    {"path": "/daily/sunrise_still/8_20_2025_sunset.jpg"},
+    {"path": "/daily/sunrise_still/8_19_2025_sunset.jpg"},
+]
+
+
+class TestSelectSunsetVideo:
+    @patch(
+        "sunset_timelapse.get_timelapse.now_mountain",
+        return_value=datetime(2025, 8, 20),
+    )
+    def test_select_tonights_video(self, mock_now):
+        """Test selecting tonight's video when available."""
+        video_id, video_url, descriptor = select_sunset_video(MOCK_TIMELAPSE_DATA)
+
+        assert video_id == "8_20_2025_sunset_timelapse"
+        assert (
+            video_url
+            == "https://glacier.org/webcam-timelapse/?type=daily&id=8_20_2025_sunset_timelapse"
+        )
+        assert descriptor == "Tonight's"
+
+    @patch(
+        "sunset_timelapse.get_timelapse.now_mountain",
+        return_value=datetime(2025, 8, 21),
+    )
+    def test_select_latest_sunset_fallback(self, mock_now):
+        """Test falling back to latest_sunset when tonight's is not available."""
+        video_id, video_url, descriptor = select_sunset_video(MOCK_TIMELAPSE_DATA)
+
+        assert video_id == "8_20_2025"
+        assert (
+            video_url
+            == "https://glacier.org/webcam-timelapse/?type=daily&id=latest_sunset"
+        )
+        assert descriptor == "Latest"
+
+    def test_select_video_empty_data(self):
+        """Test handling empty data."""
+        result = select_sunset_video([])
+
+        assert result == (None, None, None)
+
+    @patch(
+        "sunset_timelapse.get_timelapse.now_mountain",
+        return_value=datetime(2025, 8, 21),
+    )
+    def test_select_video_no_sunset_entries(self, mock_now):
+        """No arbitrary-entry fallback: sunrise-only feeds return nothing."""
+        sunrise_only = [
+            {"date": "2025-08-20 07:19:06.770128"},
+            {
+                "id": "8_20_2025_sunrise_timelapse",
+                "vid_src": "/daily/sunrise_vid/8_20_2025_sunrise_timelapse.mp4",
+                "url": "https://glacier.org/webcam-timelapse/?type=daily&id=8_20_2025_sunrise_timelapse",
+            },
+        ]
+
+        result = select_sunset_video(sunrise_only)
+
+        assert result == (None, None, None)
+
+
+class TestFindMatchingSunsetThumbnail:
+    def test_find_matching_thumbnail_success(self):
+        """Test finding matching thumbnail for a sunset video."""
+        result = find_matching_sunset_thumbnail(
+            "8_20_2025_sunset_timelapse", MOCK_THUMBNAIL_DATA
+        )
+
+        assert result == "https://glacier.org/daily/sunrise_still/8_20_2025_sunset.jpg"
+
+    def test_find_matching_thumbnail_date_only_id(self):
+        """The latest_sunset fallback yields a bare date id — still matches."""
+        result = find_matching_sunset_thumbnail("8_20_2025", MOCK_THUMBNAIL_DATA)
+
+        assert result == "https://glacier.org/daily/sunrise_still/8_20_2025_sunset.jpg"
+
+    def test_find_matching_thumbnail_does_not_match_sunrise(self):
+        """A date with only a sunrise thumbnail must not match."""
+        sunrise_only = [
+            {"date": "2025-08-20 21:19:30.366413"},
+            {"path": "/daily/sunrise_still/8_20_2025_sunrise.jpg"},
+        ]
+
+        result = find_matching_sunset_thumbnail(
+            "8_20_2025_sunset_timelapse", sunrise_only
+        )
+
+        assert result is None
+
+    def test_find_matching_thumbnail_no_match(self):
+        """Test when no matching thumbnail is found."""
+        result = find_matching_sunset_thumbnail(
+            "8_22_2025_sunset_timelapse", MOCK_THUMBNAIL_DATA
+        )
+
+        assert result is None
+
+    def test_find_matching_thumbnail_empty_data(self):
+        """Test handling empty thumbnail data."""
+        result = find_matching_sunset_thumbnail("8_20_2025_sunset_timelapse", [])
+
+        assert result is None
+
+    def test_find_matching_thumbnail_empty_video_id(self):
+        """Test handling empty video ID."""
+        result = find_matching_sunset_thumbnail("", MOCK_THUMBNAIL_DATA)
+
+        assert result is None
+
+
+class TestProcessSunsetVideo:
+    @patch("sunset_timelapse.get_timelapse.fetch_glacier_data")
+    @patch(
+        "sunset_timelapse.get_timelapse.now_mountain",
+        return_value=datetime(2025, 8, 20),
+    )
+    def test_process_sunset_video_success(self, mock_now, mock_fetch_data):
+        """Test successful video processing end to end."""
+
+        def fetch_side_effect(endpoint_type):
+            if endpoint_type == "timelapse":
+                return MOCK_TIMELAPSE_DATA
+            if endpoint_type == "thumbnails":
+                return MOCK_THUMBNAIL_DATA
+            return []
+
+        mock_fetch_data.side_effect = fetch_side_effect
+
+        result = process_sunset_video()
+
+        assert result == (
+            "https://glacier.org/webcam-timelapse/?type=daily&id=8_20_2025_sunset_timelapse",
+            "https://glacier.org/daily/sunrise_still/8_20_2025_sunset.jpg",
+            "Tonight's",
+        )
+
+    @patch("sunset_timelapse.get_timelapse.fetch_glacier_data")
+    def test_process_sunset_video_fetch_failure(self, mock_fetch_data):
+        """Test handling when data fetching fails."""
+
+        def fetch_side_effect(endpoint_type):
+            if endpoint_type == "timelapse":
+                return []
+            if endpoint_type == "thumbnails":
+                return MOCK_THUMBNAIL_DATA
+            return []
+
+        mock_fetch_data.side_effect = fetch_side_effect
+
+        result = process_sunset_video()
+
+        assert result == ("", "", "")
+
+    @patch("sunset_timelapse.get_timelapse.fetch_glacier_data")
+    @patch("sunset_timelapse.get_timelapse.select_sunset_video")
+    def test_process_sunset_video_no_suitable_video(
+        self, mock_select_video, mock_fetch_data
+    ):
+        """Test handling when no suitable video is found."""
+
+        def fetch_side_effect(endpoint_type):
+            if endpoint_type == "timelapse":
+                return MOCK_TIMELAPSE_DATA
+            if endpoint_type == "thumbnails":
+                return MOCK_THUMBNAIL_DATA
+            return []
+
+        mock_fetch_data.side_effect = fetch_side_effect
+        mock_select_video.return_value = (None, None, None)
+
+        result = process_sunset_video()
+
+        assert result == ("", "", "")
+
+    @patch("sunset_timelapse.get_timelapse.fetch_glacier_data")
+    @patch("sunset_timelapse.get_timelapse.select_sunset_video")
+    @patch("sunset_timelapse.get_timelapse.find_matching_sunset_thumbnail")
+    def test_process_sunset_video_no_matching_thumbnail(
+        self,
+        mock_find_thumbnail,
+        mock_select_video,
+        mock_fetch_data,
+    ):
+        """Test handling when no matching thumbnail is found."""
+
+        def fetch_side_effect(endpoint_type):
+            if endpoint_type == "timelapse":
+                return MOCK_TIMELAPSE_DATA
+            if endpoint_type == "thumbnails":
+                return MOCK_THUMBNAIL_DATA
+            return []
+
+        mock_fetch_data.side_effect = fetch_side_effect
+        mock_select_video.return_value = (
+            "8_20_2025_sunset_timelapse",
+            "https://glacier.org/webcam-timelapse/?type=daily&id=8_20_2025_sunset_timelapse",
+            "Tonight's",
+        )
+        mock_find_thumbnail.return_value = None
+
+        result = process_sunset_video()
+
+        assert result == ("", "", "")
+
+    @patch("sunset_timelapse.get_timelapse.fetch_glacier_data")
+    def test_process_sunset_video_exception_handling(self, mock_fetch_data):
+        """Test handling unexpected exceptions."""
+        mock_fetch_data.side_effect = Exception("Unexpected error")
+
+        result = process_sunset_video()
+
+        assert result == ("", "", "")

--- a/test/test_web_version.py
+++ b/test/test_web_version.py
@@ -91,6 +91,9 @@ def sample_data():
         "sunrise_vid": "",
         "sunrise_still": "",
         "sunrise_str": "",
+        "sunset_vid": "",
+        "sunset_still": "",
+        "sunset_str": "",
     }
 
 
@@ -258,9 +261,45 @@ def test_wifi_renders_structured_data(sample_data):
         assert "Red Bus Hiking Stick Medallion" not in content
 
 
+def test_sunset_template_renders_video(sample_data):
+    """Sunset template shows the linked thumbnail when tonight's video exists."""
+    sample_data["sunset_vid"] = "https://glacier.org/webcam-timelapse/?type=daily&id=x"
+    sample_data["sunset_still"] = "https://glacier.org/daily/sunrise_still/x_sunset.jpg"
+    sample_data["sunset_str"] = "Tonight's"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_file = os.path.join(tmpdir, "sunset.html")
+        web_version(
+            sample_data, file_name=out_file, template_path="sunset_template.html"
+        )
+        with open(out_file, encoding="utf-8") as f:
+            content = f.read()
+        assert "Tonight's Sunset at Glacier" in content
+        assert 'href="https://glacier.org/webcam-timelapse/?type=daily&id=x"' in content
+        assert 'src="https://glacier.org/daily/sunrise_still/x_sunset.jpg"' in content
+        assert "Click to watch the timelapse" in content
+        assert "isn't available" not in content
+
+
+def test_sunset_template_fallback_when_blank(sample_data):
+    """Sunset template shows the fallback message when fields are blank."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_file = os.path.join(tmpdir, "sunset.html")
+        web_version(
+            sample_data, file_name=out_file, template_path="sunset_template.html"
+        )
+        with open(out_file, encoding="utf-8") as f:
+            content = f.read()
+        assert "isn't available" in content
+        assert "Click to watch the timelapse" not in content
+
+
 @pytest.mark.parametrize(
     "template",
-    ["email_html/email_template.html", "email_html/wifi_email.html"],
+    [
+        "email_html/email_template.html",
+        "email_html/wifi_email.html",
+        "email_html/sunset_template.html",
+    ],
 )
 def test_email_template_no_bare_truthiness(template):
     """Liquid treats empty strings as truthy, unlike Jinja2.

--- a/test/test_web_version.py
+++ b/test/test_web_version.py
@@ -273,7 +273,7 @@ def test_sunset_template_renders_video(sample_data):
         )
         with open(out_file, encoding="utf-8") as f:
             content = f.read()
-        assert "Tonight's Sunset at Glacier" in content
+        assert "Tonight's Glacier Sunset" in content
         assert 'href="https://glacier.org/webcam-timelapse/?type=daily&id=x"' in content
         assert 'src="https://glacier.org/daily/sunrise_still/x_sunset.jpg"' in content
         assert "Click to watch the timelapse" in content


### PR DESCRIPTION
## Summary

Adds an evening sunset timelapse email, sent to the `Sunset Timelapse` Drip tag when the timelapse system finishes uploading tonight's video. The morning daily update flow is unchanged.

- New `sunset_timelapse/` module selects tonight's sunset video and matching thumbnail from the existing timelapse/thumbnail feeds, with a `latest_sunset` fallback for the web version.
- `main.py --sunset` regenerates email.json, verifies tonight's video is actually available (`sunset_content_ok` — today-or-nothing, never sends a stale video), then fires the new `Sunset Timelapse trigger` Drip event.
- New `email_html/sunset_template.html` (Liquid + Jinja2-compatible) titled "Tonight's Glacier Sunset", with a graceful fallback state when the video is missing.
- Sunset fields added to the `MODULES` registry so email.json / the web API carry them; the daily and wifi templates don't reference them.
- Sunrise `select_video()` fallback now only picks sunrise entries, since the feed also carries sunset entries.
- Drip tag/event strings centralized in `shared/constants.py`.

## Testing

- 66 new/updated tests pass (`test_sunset_timelapse.py`, `test_main.py`, `test_drip.py`, `test_web_version.py`, integration tests).
- Rendered both template states (video present / missing) through the real Liquid→Jinja2 pipeline and visually verified.
- Verified the morning email path is untouched: same default Drip event, same subscriber tags, `email_content_ok()` unchanged, daily templates reference no sunset fields.