### PR TITLE
Add "Stop Sunset Timelapse emails" link to sunset email footer

### DIFF
--- a/email_html/sunset_template.html
+++ b/email_html/sunset_template.html
@@ -95,6 +95,7 @@
                                         <a href="https://glacier.org/webcam-timelapse/" style="color: #6c8d3b;">All webcam timelapses</a>
                                     </p>
                                     <p style="font-size: 12px; line-height: 1.8; color: #666666; margin: 10px 0 0;">
+                                        <a href="http://api.glacier.org/dripactions?action=stopsunset&email={{ subscriber.email }}" style="color: #6c8d3b;">Stop Sunset Timelapse emails</a> ·
                                         <a href="{{ unsubscribe_url }}" style="color: #6c8d3b;">Unsubscribe from all GNPC mailings</a>
                                     </p>
                                     <p style="font-size: 11px; color: #999999; margin: 20px 0 0;">

--- a/test/test_web_version.py
+++ b/test/test_web_version.py
@@ -278,6 +278,7 @@ def test_sunset_template_renders_video(sample_data):
         assert 'src="https://glacier.org/daily/sunrise_still/x_sunset.jpg"' in content
         assert "Click to watch the timelapse" in content
         assert "isn't available" not in content
+        assert "http://api.glacier.org/dripactions?action=stopsunset&email=" in content
 
 
 def test_sunset_template_fallback_when_blank(sample_data):


### PR DESCRIPTION
## Summary

Adds a per-list opt-out link to the sunset email footer, next to the global unsubscribe link:

`http://api.glacier.org/dripactions?action=stopsunset&email={{ subscriber.email }}`

This hits the new `stopsunset` dripactions handler on api.glacier.org, which removes the subscriber's "Sunset Timelapse" tag — dropping them from the sunset send list without unsubscribing them from other GNPC mailings. Mirrors the daily email's "Stop Glacier Daily Updates" link.

## Testing

- Added an assertion to `test_sunset_template_renders_video` that the stopsunset link renders.
- All web version tests, ruff, and ty pass.