### PR TITLE
Remove "All webcam timelapses" footer link from sunset email

### DIFF
--- a/email_html/sunset_template.html
+++ b/email_html/sunset_template.html
@@ -91,8 +91,7 @@
                                         {{ inline_postal_address }}
                                     </p>
                                     <p style="font-size: 12px; line-height: 1.8; color: #666666; margin: 0;">
-                                        <a href="http://glacier.org/" style="color: #6c8d3b;">glacier.org</a> ·
-                                        <a href="https://glacier.org/webcam-timelapse/" style="color: #6c8d3b;">All webcam timelapses</a>
+                                        <a href="http://glacier.org/" style="color: #6c8d3b;">glacier.org</a>
                                     </p>
                                     <p style="font-size: 12px; line-height: 1.8; color: #666666; margin: 10px 0 0;">
                                         <a href="http://api.glacier.org/dripactions?action=stopsunset&email={{ subscriber.email }}" style="color: #6c8d3b;">Stop Sunset Timelapse emails</a> ·


### PR DESCRIPTION
Removes the "All webcam timelapses" link from the sunset email footer — the bare webcam-timelapse page isn't useful without query params. The glacier.org link remains.