### PR TITLE
Exclude tickets from product of the day

### DIFF
--- a/product_otd/product.py
+++ b/product_otd/product.py
@@ -33,6 +33,7 @@ query Products($cursor: String) {{
       node {{
         handle
         title
+        tags
         description
         totalInventory
         tracksInventory
@@ -115,12 +116,22 @@ def _fetch_eligible_products(endpoint: str, headers: dict) -> list[dict]:
     return products
 
 
+def _is_ticket(node: dict) -> bool:
+    """Event tickets (e.g. Singers & Dancers) shouldn't be featured as products."""
+    searchable = [node.get("title") or "", *(node.get("tags") or [])]
+    return any("ticket" in text.lower() for text in searchable)
+
+
 def _build_product_data(node: dict) -> dict | None:
     """Convert a Shopify product node into our internal dict.
 
-    Returns None if the product is missing an image or is out of stock.
-    Products that don't track inventory are treated as always available.
+    Returns None if the product is a ticket, is missing an image,
+    or is out of stock. Products that don't track inventory are
+    treated as always available.
     """
+    if _is_ticket(node):
+        return None
+
     featured = node.get("featuredImage")
     if not featured or not featured.get("url"):
         return None

--- a/test/test_potd.py
+++ b/test/test_potd.py
@@ -83,6 +83,41 @@ class TestGetProduct:
             assert product_link == "https://shop.glacier.org/products/test-product"
             assert desc == "Test product description"
 
+    def test_get_product_skips_tickets(self, mock_graphql_response, mock_env_vars):
+        """Ticket products are never selected as product of the day."""
+        ticket_node = {
+            "handle": "july-15th-singers-dancers-ticket",
+            "title": "July 15th: Singers & Dancers Ticket",
+            "tags": ["exclude-from-sold-out", "s&d-ticket", "scheduled"],
+            "description": "Event ticket",
+            "totalInventory": 100,
+            "tracksInventory": True,
+            "seo": {"description": "Event ticket"},
+            "featuredImage": {"url": "https://example.com/ticket.jpg"},
+        }
+        edges = mock_graphql_response["data"]["products"]["edges"]
+        edges.insert(0, {"node": ticket_node})
+
+        mock_rng = MagicMock()
+        mock_rng.randrange.side_effect = [0, 1]
+        with (
+            patch("requests.post") as mock_post,
+            patch("product_otd.product.resize_image", return_value=True),
+            patch("product_otd.product.upload_potd") as mock_upload,
+            patch("random.Random", return_value=mock_rng),
+        ):
+            mock_post.return_value = Mock(
+                status_code=200,
+                text=json.dumps(mock_graphql_response),
+                raise_for_status=Mock(),
+            )
+            mock_upload.return_value = "https://example.com/uploaded.jpg"
+
+            title, _image_url, product_link, _desc = get_product()
+
+            assert title == "Test Product"
+            assert product_link == "https://shop.glacier.org/products/test-product"
+
     def test_get_product_image_fetch_fails(self, mock_graphql_response, mock_env_vars):
         """Test that failed image fetch returns empty tuple."""
         mock_rng = MagicMock()


### PR DESCRIPTION
## Summary
- Fetch product `tags` in the Shopify products query and skip any product with "ticket" in its title or tags when selecting the product of the day
- Rejected products fall through to the existing random-retry loop, so a regular product is picked instead

Verified against the live store: exactly the 5 Singers & Dancers ticket listings (of 752 active products) are excluded, and today's pick resolves to a real product.

## Testing
- Added `test_get_product_skips_tickets`; all tests in `test/test_potd.py` pass
- ruff check, ruff format, and ty check all clean