### PR TITLE
Let retry decorator handle AQI JSON decode errors

### DIFF
--- a/test/weather/test_aqi_sunset.py
+++ b/test/weather/test_aqi_sunset.py
@@ -132,8 +132,8 @@ def test_get_air_quality_no_data():
 
 
 def test_get_air_quality_json_error():
-    """Test handling of JSON decoding error"""
-    with patch("requests.get") as mock_get:
+    """Test that a JSON decoding error is retried, then returns the default"""
+    with patch("requests.get") as mock_get, patch("shared.retry.sleep"):
         mock_get.return_value.json.side_effect = requests.exceptions.JSONDecodeError(
             "Invalid JSON", "", 0
         )
@@ -141,6 +141,7 @@ def test_get_air_quality_json_error():
         aqi = get_air_quality()
 
         assert aqi == ""
+        assert mock_get.call_count == 3
 
 
 def test_get_air_quality_request_error():

--- a/weather/weather_aqi.py
+++ b/weather/weather_aqi.py
@@ -81,10 +81,6 @@ def get_air_quality() -> int | str:
 
         return ""
 
-    except requests.exceptions.JSONDecodeError:
-        logger.error("AQI JSON decoding error")
-        return ""
-
     except (KeyError, IndexError, TypeError) as e:
         logger.error("Unexpected AQI response structure: %s", e)
         return ""


### PR DESCRIPTION
## Summary
The NPS AQI feed occasionally returns a 200 with a non-JSON body (seen in production on 2026-07-16 at 13:01). `get_air_quality()` caught `requests.exceptions.JSONDecodeError` internally and returned `""` immediately — but that exception is a subclass of `RequestException`, which the `@retry` decorator already handles. The inner except block was short-circuiting the retry, so a single transient bad response dropped AQI from the email instead of being retried.

## Changes
- Remove the inner `except requests.exceptions.JSONDecodeError` block so the `@retry(3, ...)` decorator retries transient bad responses with backoff. After exhausted attempts it returns the same `""` default and logs an error.
- Update `test_get_air_quality_json_error` to patch the retry sleep and assert 3 attempts are made.

## Testing
- `uv run pytest test/weather/test_aqi_sunset.py` — 10 passed
- ruff check, ruff format, ty check all pass