### PR TITLE
Scope scheduled daily start/end merge to daily update tags

### DIFF
--- a/drip/drip_actions.py
+++ b/drip/drip_actions.py
@@ -9,7 +9,12 @@ import requests
 
 from drip.scheduled_subs import update_scheduled_subs
 from drip.subscriber_list import subscriber_list
-from shared.constants import DAILY_UPDATE_EVENT_ACTION, DRIP_BATCH_SIZE
+from shared.constants import (
+    DAILY_UPDATE_EVENT_ACTION,
+    DAILY_UPDATE_TAG,
+    DRIP_BATCH_SIZE,
+    TEST_DAILY_UPDATE_TAG,
+)
 from shared.logging_config import get_logger
 from shared.retry import retry
 from shared.settings import get_settings
@@ -38,14 +43,17 @@ def get_subs(tag: str) -> list:
     updates = update_scheduled_subs()
     subs = subscriber_list(tag)
 
-    # Update subscriber list based on changes today (drip updates aren't fast enough)
-    for i in updates["start"]:
-        if i not in subs:
-            subs.append(i)
+    # Scheduled starts/ends only affect the daily update list; merging them
+    # here works around Drip's tag indexing lagging behind same-day changes.
+    # Other lists (e.g. sunset) must not inherit daily-only subscribers.
+    if tag in (DAILY_UPDATE_TAG, TEST_DAILY_UPDATE_TAG):
+        for i in updates["start"]:
+            if i not in subs:
+                subs.append(i)
 
-    for i in updates["end"]:
-        if i in subs:
-            subs.remove(i)
+        for i in updates["end"]:
+            if i in subs:
+                subs.remove(i)
 
     return subs
 

--- a/test/test_drip.py
+++ b/test/test_drip.py
@@ -94,12 +94,34 @@ def test_update_subscriber_failure(monkeypatch, mock_required_settings):
 
 
 def test_get_subs_merges(monkeypatch):
+    from shared.constants import DAILY_UPDATE_TAG
+
     monkeypatch.setattr(
         drip_actions, "update_scheduled_subs", lambda: {"start": ["a"], "end": ["b"]}
     )
     monkeypatch.setattr(drip_actions, "subscriber_list", lambda tag: ["b", "c"])
-    result = drip_actions.get_subs("tag")
+    result = drip_actions.get_subs(DAILY_UPDATE_TAG)
     assert set(result) == {"a", "c"}
+
+
+def test_get_subs_sunset_ignores_scheduled_daily_changes(monkeypatch):
+    """Regression: scheduled daily starts/ends must not leak into the sunset
+    send list — daily-only signups were getting the sunset email on the day
+    their daily subscription began."""
+    from shared.constants import SUNSET_TIMELAPSE_TAG
+
+    monkeypatch.setattr(
+        drip_actions,
+        "update_scheduled_subs",
+        lambda: {"start": ["daily-only@example.com"], "end": ["ending@example.com"]},
+    )
+    monkeypatch.setattr(
+        drip_actions,
+        "subscriber_list",
+        lambda tag: ["sunset@example.com", "ending@example.com"],
+    )
+    result = drip_actions.get_subs(SUNSET_TIMELAPSE_TAG)
+    assert result == ["sunset@example.com", "ending@example.com"]
 
 
 def test_bulk_workflow_trigger(monkeypatch, mock_required_settings):


### PR DESCRIPTION
## Problem
People with only the "Glacier Daily Update" tag (not "Sunset Timelapse") were receiving the sunset email — once, on the day they signed up for daily updates.

## Cause
`get_subs()` unconditionally merged the day's scheduled daily-update starts/ends into whatever send list was requested. The merge exists to work around Drip's tag indexing lagging behind same-day tag changes, and is correct for the morning daily email — but the evening sunset run calls `get_subs("Sunset Timelapse")` and got the same treatment, so anyone whose daily subscription started that day was injected into the sunset send list and had the sunset workflow trigger fired at them.

The mirror bug also existed: a sunset subscriber whose *daily* subscription ended that day was silently dropped from that evening's sunset email.

## Fix
Apply the start/end merge only when the requested tag is a daily update tag (`DAILY_UPDATE_TAG` / `TEST_DAILY_UPDATE_TAG`). `update_scheduled_subs()` still runs on every invocation, so the Drip-side tag updates are unchanged.

## Tests
- Updated `test_get_subs_merges` to use the daily tag (the merge case).
- Added `test_get_subs_sunset_ignores_scheduled_daily_changes`: scheduled daily starts are not added to the sunset list, and scheduled daily ends are not removed from it.
- Full suite: 674 passed.