### PR TITLE
Rotate peaks evenly and correct mismatched Wikipedia data

### DIFF
--- a/peak/PeaksCSV.csv
+++ b/peak/PeaksCSV.csv
@@ -30,7 +30,6 @@ Whitecrow Mountain,48.90862,-113.82412,7710
 Stoney Indian Peaks,48.89995,-113.85730,9110
 Wahcheeche Mountain,48.88280,-113.87421,8477
 Sentinel Mountain,48.97894,-113.74630,8245
-Bear Mountain,48.95391,-113.75008,8796
 Gable Mountain,48.90596,-113.67398,9262
 Yellow Mountain,48.88183,-113.63723,8766
 Chief Mountain,48.93269,-113.60976,9080

--- a/peak/fetch_wikipedia.py
+++ b/peak/fetch_wikipedia.py
@@ -174,7 +174,14 @@ def get_page_content(
 def verify_article(
     article_text: str, peak_lat: float, peak_lon: float, article_coords: list | None
 ) -> bool:
-    """Verify that an article is about a peak in Glacier National Park."""
+    """
+    Verify that an article is about this specific peak.
+
+    Nearly every Glacier peak article mentions Montana, so a text mention alone
+    cannot tell one peak from its neighbours -- it only rules out articles about
+    somewhere else entirely. When the article carries coordinates those decide
+    the match; the text check is just a fallback for articles that have none.
+    """
     text_lower = article_text.lower()
 
     # Check for GNP or Montana mentions
@@ -185,17 +192,14 @@ def verify_article(
         or "livingston range" in text_lower
     )
 
-    # Check coordinates if available
-    coords_match = False
     if article_coords:
-        for coord in article_coords:
-            lat_diff = abs(coord.get("lat", 0) - peak_lat)
-            lon_diff = abs(coord.get("lon", 0) - peak_lon)
-            if lat_diff < WIKI_COORD_TOLERANCE and lon_diff < WIKI_COORD_TOLERANCE:
-                coords_match = True
-                break
+        return any(
+            abs(coord.get("lat", 0) - peak_lat) < WIKI_COORD_TOLERANCE
+            and abs(coord.get("lon", 0) - peak_lon) < WIKI_COORD_TOLERANCE
+            for coord in article_coords
+        )
 
-    return gnp_mentions or coords_match
+    return gnp_mentions
 
 
 def find_wikipedia_article(

--- a/peak/peak.py
+++ b/peak/peak.py
@@ -15,7 +15,13 @@ logger = get_logger(__name__)
 
 SCRIPT_DIR = Path(__file__).parent
 WIKIPEDIA_JSON = SCRIPT_DIR / "peaks_wikipedia.json"
+PEAKS_CSV = SCRIPT_DIR / "PeaksCSV.csv"
 PEAK_COORD_MATCH_TOLERANCE = 0.001
+
+# Anchor for the peak rotation. Peaks are shuffled into a new random order every
+# len(peaks) days and then handed out one per day, so every peak appears exactly
+# once per cycle. Changing this date reshuffles which peak lands on which day.
+PEAK_CYCLE_EPOCH = date(2026, 1, 1)
 
 
 def _get_peak_summary(name: str, lat: float, lon: float) -> str | None:
@@ -34,6 +40,21 @@ def _get_peak_summary(name: str, lat: float, lon: float) -> str | None:
     return None
 
 
+def select_peak(peaks: list[dict], day: date) -> dict:
+    """
+    Pick the peak for a given day.
+
+    Each cycle of len(peaks) days gets its own seeded shuffle of the full list,
+    and the day's position within that cycle indexes into it. Every peak is used
+    exactly once per cycle, so coverage is even instead of the long droughts and
+    clustered repeats that come from drawing at random each day.
+    """
+    cycle, offset = divmod((day - PEAK_CYCLE_EPOCH).days, len(peaks))
+    order = list(peaks)
+    random.Random(f"peaks-{cycle}").shuffle(order)  # noqa: S311
+    return order[offset]
+
+
 def peak(test: bool = False, skip_upload: bool = False) -> tuple[str, str | None, str]:
     """
     Select a random peak, and return the relevant information.
@@ -41,12 +62,10 @@ def peak(test: bool = False, skip_upload: bool = False) -> tuple[str, str | None
     if test:
         logger.debug("Test mode.")
 
-    with open("peak/PeaksCSV.csv", encoding="utf-8") as p:
+    with open(PEAKS_CSV, encoding="utf-8") as p:
         peaks = list(csv.DictReader(p))
 
-    # Select a random one with current date as seed
-    rng = random.Random(date.today().strftime("%Y%m%d"))  # noqa: S311
-    today = rng.choice(peaks)
+    today = select_peak(peaks, date.today())
 
     peak_img = peak_sat(today, skip_upload=skip_upload) if not test else None
 

--- a/peak/peaks_no_wikipedia.csv
+++ b/peak/peaks_no_wikipedia.csv
@@ -10,6 +10,7 @@ Loneman Mountain,48.48909,-113.76938,7181
 Threesuns Mountain,48.49027,-113.65581,8205
 Threetops Mountain,48.45753,-113.70453,6790
 Statuary Mountain,48.39168,-113.49219,8250
+Chief Lodgepole Peak,48.43074,-113.42501,7682
 Rising Bull Ridge,48.4491,-113.45522,8400
 Bison Mountain,48.46527,-113.31032,7833
 Running Rabbit Mountain,48.26055,-113.54021,7674

--- a/peak/peaks_wikipedia.json
+++ b/peak/peaks_wikipedia.json
@@ -256,9 +256,9 @@
       "lon": -113.75765,
       "elevation": 8841,
       "has_article": true,
-      "wikipedia_url": "https://en.wikipedia.org/wiki/Curly_Bear_Mountain",
-      "wikipedia_text": "Curly Bear Mountain (8,099 feet (2,469 m)) is located in the Lewis Range, Glacier National Park in the U.S. state of Montana. Curly Bear Mountain is easily seen from the village of Saint Mary, Montana rising just west of Divide Mountain. The peak was named after Blackfoot warrior and historian Curly Bear (Kyáiyo-xusi).\n\n\n== See also ==\nMountains and mountain ranges of Glacier National Park (U.S.)\n\n\n== References ==",
-      "summary": "Named for Blackfoot warrior and historian Curly Bear (Ky&aacute;iyo-xusi). Easily seen from St. Mary village."
+      "wikipedia_url": "https://en.wikipedia.org/wiki/Bear_Mountain_(Glacier_County,_Montana)",
+      "wikipedia_text": "Bear Mountain (8,841 feet (2,695 m)) is located in the northern Lewis Range, Glacier National Park in the U.S. state of Montana. Cosley Lake, followed by Glenns Lake to the southwest of the mountain. Mokowanis Lake is also visible from the peak. The mountain has tremendous views of the east face of Mount Cleveland, the north face of Mount Merritt, and the east face of Chief Mountain.\n\n\n== Climate ==\nBear Mountain is located in an alpine subarctic climate zone characterized by long, usually very cold winters, and short, cool to mild summers. Winter temperatures can drop below −10 °F with wind chill factors below −30 °F.\n\n\n== Geology ==\nLike the other mountains in Glacier National Park, Bear Mountain is composed of sedimentary rock laid down during the Precambrian to Jurassic periods. Formed in shallow seas, this sedimentary rock was initially uplifted beginning 170 million years ago when the Lewis Overthrust fault pushed an enormous slab of precambrian rocks 3 mi (4.8 km) thick, 50 miles (80 km) wide and 160 miles (260 km) long over younger rock of the cretaceous period.\n\n\n== Gallery ==\n\n\n== See also ==\nMountains and mountain ranges of Glacier National Park (U.S.)\n\n\n== References ==",
+      "summary": "Overlooks Cosley and Glenns Lakes in the northern Lewis Range, with views of Mount Cleveland&#x27;s east face."
     },
     {
       "name": "Mount Cleveland",
@@ -311,16 +311,6 @@
       "summary": "In the Belly River area, 1.3 miles south of the Canadian border. Summit rises 2,900 feet in one mile."
     },
     {
-      "name": "Bear Mountain",
-      "lat": 48.95391,
-      "lon": -113.75008,
-      "elevation": 8796,
-      "has_article": true,
-      "wikipedia_url": "https://en.wikipedia.org/wiki/Curly_Bear_Mountain",
-      "wikipedia_text": "Curly Bear Mountain (8,099 feet (2,469 m)) is located in the Lewis Range, Glacier National Park in the U.S. state of Montana. Curly Bear Mountain is easily seen from the village of Saint Mary, Montana rising just west of Divide Mountain. The peak was named after Blackfoot warrior and historian Curly Bear (Kyáiyo-xusi).\n\n\n== See also ==\nMountains and mountain ranges of Glacier National Park (U.S.)\n\n\n== References ==",
-      "summary": "Named for Blackfoot warrior and historian Curly Bear (Ky&aacute;iyo-xusi). Easily seen from St. Mary village."
-    },
-    {
       "name": "Gable Mountain",
       "lat": 48.90596,
       "lon": -113.67398,
@@ -356,9 +346,9 @@
       "lon": -113.6248,
       "elevation": 8284,
       "has_article": true,
-      "wikipedia_url": "https://en.wikipedia.org/wiki/Chief_Mountain",
-      "wikipedia_text": "Chief Mountain (Blackfoot: Ninaistako) (9,085 feet or 2,769 metres) is located in the U.S. state of Montana on the eastern border of Glacier National Park and the Blackfeet Indian Reservation. The mountain is one of the most prominent peaks and rock formations along the Rocky Mountain Front, a 200-mile-long (320 km) overthrust fault, known as the Lewis Overthrust, which extends from central Montana into southern Alberta, Canada.\n\n\n== Geology ==\nChief Mountain is an example of a klippe. It consists of a Precambrian block which rests directly above much younger Cretaceous gray shales. The 1450-1400 million year old Precambrian rocks are 1300-1400 million years older than the Cretaceous rocks at the base of the mountain.\nHaving an older layer of rock juxtaposed atop younger basement rocks is found on occasion in thrust faults and is commonplace along the Lewis Overthrust which extends from central Montana to far southern Alberta. The surrounding portion of the thrust sheet has been removed by erosion leaving behind this and a few other isolated blocks of Proterozoic rock.\n\n\n== History and significance ==\nChief Mountain has been a sacred mountain to the tribes of Native Americans in the United States and First Nations in Canada for hundreds of years. The Blackfoot name for the mountain is Nínaiistáko. The peak is easily seen from Montana and Alberta due to the rapid 5,000-foot (1,500 m) altitude gain over the Great Plains which are immediately east of the mountain.\nThe mountain was seen by white explorers in the late 18th century and was known as \"Kings Peak\" on maps produced in the United Kingdom in 1795. In the early 1900s as white settlers came to the area, they observed native burial sites scattered along the base of the mountain. The name was changed in the late 19th century in reflection of Blackfeet naming of the mountain which was \"Great Chief\". When Glacier National Park was created in 1910, the summit and most prominent eastern slopes of the mountain were located within the park, leaving only the lower slopes within Blackfeet Indian Reservation.\nNatives from all over North America travel to the base of the mountain for sweet grass ceremonies, placing of prayer flags and other religious rites. Elders from Southern Alberta's Siksika Band (where the Great Chief Crowfoot hailed from) and other First Nation groups have an oral tradition that near the end of days, a Great White God would appear from the top of Chief Mountain and upon his departure, the mountain would crumble and be destroyed.\n\n\n== Climbing ==\nThe eastern face of the mountain rises over 1,500 ft (460 m) vertically and the easiest route on this section is rated class 4 by mountaineers. The rock is also primarily sedimentary and provides poor anchor points, which in turn is a contributing factor to the difficulty rating. Henry Stimson and two other explorers, including a Blackfeet Indian, climbed the difficult eastern face on September 8, 1892, and this is the first known ascent of the peak by white explorers. Upon the summit, Stimson's party observed ceremonial remains including bison skulls that had been left behind by Native Americans. The eastern face of the peak was not successfully climbed again until 1951. Though the summit can be gained by approaching from the west, the easiest access is from the east, and the Blackfeet tribe may issue access permits to cross reservation lands. This entire area is sacred to the Blackfeet Native Americans. National Park Service visitor centers at St. Mary, Montana and at Many Glacier have additional information available.\n\n\n== See also ==\n\nRocky Mountains\nNinaki Mountain\nMountains and mountain ranges of Glacier National Park (U.S.)\n\n\n== References ==",
-      "summary": "Adjacent to Chief Mountain. Ninaki means &#x27;chief&#x27; in Blackfoot."
+      "wikipedia_url": "https://en.wikipedia.org/wiki/Ninaki_Mountain",
+      "wikipedia_text": "Ninaki Mountain is located in Montana, 20 kilometres (12 miles) southwest of Carway, Alberta and 1 kilometre (0.62 miles) southwest of Chief Mountain. It was named in honour of the sacrifice of the wife who threw her baby, then herself off the mountain in reaction to the death of her war-chief husband as a result of a battle which took place between Peigan and Blackfeet warriors.\n\n\n== References ==\n\n\n== External links ==\n\nNinaki photo: Flickr",
+      "summary": "Adjacent to Chief Mountain; named in Blackfoot tradition for the wife of a war chief."
     },
     {
       "name": "Logging Mountain",
@@ -571,7 +561,7 @@
       "summary": "On ridgeline south of Ptarmigan Tunnel. Easily seen from Iceberg Lake."
     },
     {
-      "name": "Mount Henkle",
+      "name": "Mount Henkel",
       "lat": 48.82151,
       "lon": -113.68346,
       "elevation": 8770,
@@ -796,8 +786,8 @@
       "lon": -113.71508,
       "elevation": 9553,
       "has_article": true,
-      "wikipedia_url": "https://en.wikipedia.org/wiki/Mount_Gould",
-      "wikipedia_text": "Mount Gould could be:\n\nMount Gould (Montana) in Glacier National Park, United States\nMount Gould (California) in Sierra Nevada, United States\nMount Gould (Plymouth), a suburb in Plymouth, Devon, England\nMount Gould (Tasmania) in the Cradle Mountain-Lake St Clair National Park, Australia\nMount Gould (Antarctica)\nMount Gould Station, a pastoral lease in the Mid West of Western Australia",
+      "wikipedia_url": "https://en.wikipedia.org/wiki/Mount_Gould_(Montana)",
+      "wikipedia_text": "Mount Gould (9,557 ft (2,913 m)) is a peak on the Continental Divide in Glacier National Park, Montana, United States. It is the highest point of the Garden Wall, a distinctive ridge of the Lewis Range. It is most notable for its huge, steep east face, which drops 4,000 ft (1,220 m) in only one-half mile (0.8 km). This face provides a backdrop to Grinnell Lake, and is often photographed.\nMount Gould was named in 1887 by George Bird Grinnell for his hunting companion, George H. Gould, and the name was officially adopted in 1929 by the United States Board on Geographic Names.\nThe first recorded ascent of Mount Gould was in 1920, by Frank B. Wynn, Harry R. Horn, Henry H. Goddard, and party. They used the West Face route, which is the easiest and most commonly used route today. It starts from the Highline Trail, which skirts the west side of the peak, and involves some rock scrambling but no technical climbing.\nClimbing the sheer East Face of Mount Gould is theoretically possible; however the brittle, loose nature of the rock in Glacier National Park makes the ascent highly technical, unpleasant, and dangerous.\n\n\n== Climate ==\nBased on the Köppen climate classification, Mount Gould is located in an alpine subarctic climate zone characterized by long, usually very cold winters, and short, cool to mild summers. Temperatures can drop below −10 °F with wind chill factors below −30 °F.\n\n\n== Geology ==\nLike the mountains in Glacier National Park, Mount Gould is composed of sedimentary rock laid down during the Precambrian to Jurassic periods. Formed in shallow seas, this sedimentary rock was initially uplifted beginning 170 million years ago when the Lewis Overthrust fault pushed an enormous slab of precambrian rocks 3 mi (4.8 km) thick, 50 miles (80 km) wide and 160 miles (260 km) long over younger rock of the cretaceous period. The bulk of the peak is composed of limestone of the Siyeh Formation, and the conspicuous dark band on the east face is a diorite sill.\n\n\n== See also ==\nList of mountains and mountain ranges of Glacier National Park (U.S.)\n\n\n== Notes ==\n\n\n== Sources ==\nJ. Gordon Edwards and Josephine Gould, A Climber's Guide to Glacier National Park, Falcon Press, 1991. ISBN 0-87842-177-7.\n\n\n== External links ==\n\nWeather forecast: Mount Gould",
       "summary": "Part of the Garden Wall along the Continental Divide."
     },
     {
@@ -981,7 +971,7 @@
       "summary": "Named for Grinnell&#x27;s single shot dispatching a bighorn sheep while hunting in 1885."
     },
     {
-      "name": "Curley Bear Mountain",
+      "name": "Curly Bear Mountain",
       "lat": 48.65882,
       "lon": -113.45615,
       "elevation": 8099,
@@ -1146,8 +1136,8 @@
       "lon": -113.51698,
       "elevation": 8020,
       "has_article": true,
-      "wikipedia_url": "https://en.wikipedia.org/wiki/Triple_Divide_Peak",
-      "wikipedia_text": "Triple Divide Peak may refer to:\n\nTriple Divide Peak (Madera County, California)\nTriple Divide Peak (Montana) in Glacier National Park\nTriple Divide Peak (Tulare County, California)",
+      "wikipedia_url": "https://en.wikipedia.org/wiki/Triple_Divide_Peak_(Montana)",
+      "wikipedia_text": "Triple Divide Peak (8,025 feet or 2,446 metres) is located in the Lewis Range, part of the Rocky Mountains in North America. The peak is a feature of Glacier National Park in the state of Montana in the United States. The summit of the peak, the hydrological apex of the North American continent, is the point where two of the principal continental divides in North America converge: the Continental Divide of the Americas and the Northern or Laurentian Divide.\n\n\n== Hydrography ==\nWater that falls at the summit can flow either to the Pacific, Atlantic, or Arctic oceans (when Hudson Bay is considered a marginal sea of the Arctic Ocean). The International Hydrographic Organization (in its current unapproved working edition only of Limits of Oceans and Seas) defines the Hudson Bay, with its outlet extending from 62.5 to 66.5 degrees north (just a few miles south of the Arctic Circle) as being part of the Arctic Ocean, specifically \"Arctic Ocean Subdivision 9.11.\"\nNorth America is not the only continent with shores on three different oceans. Asia borders the Arctic, Indian, and Pacific Oceans, as well as the Atlantic Ocean if the Mediterranean and Black Seas are considered parts thereof. Also, Antarctica borders the Atlantic, Indian, and Pacific Oceans if the Southern Ocean is not considered a separate ocean from the former three. However, the inward-draining endorheic basins of Central and Western Asia separate all combinations of 3 of the 4 oceans bordering the continent so that no 3 of their basins meet at a single location. In the case of Antarctica, there is no freely flowing water due to ice sheets and permafrost. So Triple Divide Peak is the only single point on Earth from which water flows into three distinct oceans. Some sources consider Hudson Bay to be part of the Atlantic. Under this stipulation, because the bay is fed by drainage from Triple Divide Peak, Snow Dome, which is the triple divide between Hudson Bay, the Arctic Ocean, and Pacific Ocean, is world’s sole hydrological apex.\nRainfall on the southwestern side of the peak enters Pacific Creek, which in turn enters Nyack Creek, the Middle Fork of the Flathead River, the Flathead River through Flathead Lake, the Clark Fork River into Pend Oreille Lake, the Pend Oreille River, and the Columbia River which empties into the Pacific near Astoria, Oregon.\nThe northern slope of the mountain sheds water into Hudson Bay Creek, which then drains into Medicine Owl Creek and Red Eagle Creek.  It then empties into Saint Mary Lake, which feeds the St. Mary River, which in turn flows into the Oldman River, the South Saskatchewan River, the Saskatchewan River, and the Lake Winnipeg system, drained by the Nelson River which empties into Hudson Bay.\nMoisture on the southeastern slopes feeds into Atlantic Creek, which in turn enters the North Fork of Cut Bank Creek, Cut Bank Creek, the Marias River, and the Missouri River which joins the Mississippi River before emptying into the Atlantic's Gulf of Mexico near New Orleans.\n\n\n== Geology ==\nThe Lewis Range was formed in the Lewis Overthrust, some 59–75 million years ago, when an enormous slab of Precambrian rock faulted and slid over younger rocks from the Cretaceous period.\n\n\n== Gallery ==\n\n\n== See also ==\n\nList of mountains and mountain ranges of Glacier National Park (U.S.)\n\n\n== References ==\n\n\n== External links ==\nClimbing Triple Divide Peak",
       "summary": "Where Hudson Bay, Gulf of Mexico, and Pacific Ocean drainages meet&mdash;one of two such points in North America."
     },
     {
@@ -1231,7 +1221,7 @@
       "summary": "Northwest of Amphitheater Mountain."
     },
     {
-      "name": "Ampitheatre Mountain",
+      "name": "Amphitheater Mountain",
       "lat": 48.59956,
       "lon": -113.48779,
       "elevation": 8690,
@@ -1401,7 +1391,7 @@
       "summary": "Multi-summit formation in the Lewis Range."
     },
     {
-      "name": "Mont Phillips",
+      "name": "Mount Phillips",
       "lat": 48.47746,
       "lon": -113.52517,
       "elevation": 9494,
@@ -1515,9 +1505,9 @@
       "lat": 48.43074,
       "lon": -113.42501,
       "elevation": 7682,
-      "has_article": true,
-      "wikipedia_url": "https://en.wikipedia.org/wiki/Painted_Tepee_Peak",
-      "wikipedia_text": "Painted Tepee Peak, or simply Painted Tepee (also Tipi or Teepee) is a mountain located in Glacier National Park in the U.S. state of Montana near the Two Medicine Pass.  The altitude of the highest point is 7,650 feet (2,332 m). The summit lies to the south of Two Medicine Lake, and is within view of Grizzly Mountain, Chief Lodgepole Peak, and Mount Rockwell. The mountain lies along the Two Mountain Pass Trail.\n\n\n== See also ==\nList of mountains in Glacier County, Montana\nList of mountains and mountain ranges of Glacier National Park (U.S.)\nList of trails of Glacier County, Montana\n\n\n== Notes ==\n\n\n== References ==\n\n\n== External links ==\n Glacier National Park travel guide from Wikivoyage",
+      "has_article": false,
+      "wikipedia_url": null,
+      "wikipedia_text": null,
       "summary": "Near Painted Tepee Peak in Two Medicine area."
     },
     {
@@ -1548,7 +1538,7 @@
       "has_article": true,
       "wikipedia_url": "https://en.wikipedia.org/wiki/Mount_Helen_(Montana)",
       "wikipedia_text": "Mount Helen (8,538 feet (2,602 m)) is located in the Lewis Range, Glacier National Park in the U.S. state of Montana. Mount Helen rises immediately to the northwest roughly 3,100 feet (940 m) above Upper Two Medicine Lake in the southeastern part of Glacier National Park. The Continental Divide of the Americas passes over the summit of Mount Helen.\n\n\n== Geology ==\nLike the mountains in Glacier National Park, Mt. Helen is composed of sedimentary rock laid down during the Precambrian to Jurassic periods. Formed in shallow seas, this sedimentary rock was initially uplifted beginning 170 million years ago when the Lewis Overthrust fault pushed an enormous slab of precambrian rocks 3 mi (4.8 km) thick, 50 miles (80 km) wide and 160 miles (260 km) long over younger rock of the cretaceous period.\n\n\n== Climate ==\nBased on the Köppen climate classification, Mt. Helen is located in an alpine subarctic climate zone characterized by long, usually very cold winters, and short, cool to mild summers. Temperatures can drop below −10 °F with wind chill factors below −30 °F.\n\n\n== See also ==\nMountains and mountain ranges of Glacier National Park (U.S.)\n\n\n== References ==",
-      "summary": "Rises 3,100 feet above Upper Two Medicine Lake. The Continental Divide passes over Mount Helen's summit."
+      "summary": "Rises 3,100 feet above Upper Two Medicine Lake. The Continental Divide passes over Mount Helen&#x27;s summit."
     },
     {
       "name": "Flinsch Peak",
@@ -1666,9 +1656,9 @@
       "lon": -113.36904,
       "elevation": 8581,
       "has_article": true,
-      "wikipedia_url": "https://en.wikipedia.org/wiki/Mount_Ellsworth",
-      "wikipedia_text": "Mount Ellsworth can refer to:\n\nMount Ellsworth (Antarctica), the highest peak in the Queen Maud Mountains in Antarctica\nMount Ellsworth (Montana), in Glacier National Park, Montana, United States\nMount Ellsworth (Utah), in the Henry Mountains, Utah, United States",
-      "summary": "Named summit in the Lewis Range."
+      "wikipedia_url": "https://en.wikipedia.org/wiki/Mount_Ellsworth_(Montana)",
+      "wikipedia_text": "Mount Ellsworth (8,586 feet (2,617 m)) is located in the Lewis Range, Glacier National Park in the U.S. state of Montana. Mount Ellsworth is in the southeastern section of Glacier National Park and can be seen from Two Medicine Lake and surrounding areas. Mount Ellsworth is named, \"for \"Billy\" Ellsworth, an oldtimer who packed for the U. S. Geological Survey.\"\n\n\n== See also ==\nMountains and mountain ranges of Glacier National Park (U.S.)\n\n\n== References ==",
+      "summary": "Named for &#x27;Billy&#x27; Ellsworth, who packed for the U.S. Geological Survey. Seen from Two Medicine Lake."
     },
     {
       "name": "Mount Henry",
@@ -1846,15 +1836,15 @@
       "lon": -114.13434,
       "elevation": 6593,
       "has_article": true,
-      "wikipedia_url": "https://en.wikipedia.org/wiki/Glacier_View_Dam",
-      "wikipedia_text": "Glacier View Dam was proposed in 1943 on the North Fork of the Flathead River, on the western border of Glacier National Park in Montana. The 416-foot (127 m) tall dam,  to be designed and constructed by the U.S. Army Corps of Engineers in the canyon between Huckleberry Mountain and Glacier View Mountain, would have flooded in excess of 10,000 acres (4,000 ha) of the park. In the face of determined opposition from the National Park Service and conservation groups, the dam was never built.\n\n\n== Proposal ==\nThe Glacier View project was proposed after an earlier proposal by the Corps of Engineers and the Bonneville Power Administration to raise the level of Flathead Lake by increasing the height of Kerr Dam at its outlet was rejected, following local protests.  Located in a relatively unpopulated area, the Glacier View reservoir would have flooded lower Camas Creek and would have raised the level of Logging Lake by 50 feet (15 m), inundating much of the winter range for the park's white-tailed deer, elk, mule deer and moose. The proposed reservoir was to extend nearly to the Canada–US border, at an estimated cost of $94,962,000. The dam was supported by Montana Representative Mike Mansfield and Flathead Valley interests but was opposed by former Senator Burton K. Wheeler, local ranchers, the National Park Service, the Glacier Park Hotel Company, the Sierra Club, Society of American Foresters and the Audubon Society. Public hearings were held in 1948 and 1949. Turnout at the 1948 hearings at Kalispell was influenced by extensive flooding then occurring in the Flathead Valley. Exploratory drilling took place in 1944 and 1945 at Glacier View and Foolhen Hill. The project was terminated by a joint memorandum between the Secretary of the Interior and the Secretary of the Army on April 11, 1949, but Mansfield introduced an unsuccessful bill later in the year directing the Corps of Engineers to proceed with the dam, stating that the dam \"would not affect the beauty of the park in any way but would make it more beautiful by creating a large lake over ground that ... has no scenic attraction.\" The Corps of Engineers report on the project noted:  The park lands that will be inundated and required for freeboard of 5 feet above normal pool elevation amounts to 10,175 acres (4,118 ha), or about 1 percent of the total Glacier National Park area. This area does not lie within the rugged, glacier-covered portion of the park for which it is noted, but rather is on the western boundary line, in a little-used valley. The reservoir area is covered with lodge-pole pine, an inferior species of limited use. Other species of pine timber such as ponderosa pine, are predominate above the normal full reservoir and will not be injured by the project. Other lands inundated or required by this project are in private, State and United States Forest Service ownership and hence should be of no concern to the Park Service. Although there would be some effect on the wildlife in the area, the construction of Glacier View Reservoir would inconvenience but relatively few people as it is situated in a sparsely populated area.\nPark Service Director Newton B. Drury responded:\n\nThe effects of the proposed impoundment of the North Fork of the Flathead River upon Glacier National Park would be extraordinarily serious upon the very values with the National Park Service is obliged by law, and expected by the public, to protect ... The flooding of park land would reduce the winter range of [white-tailed deer] by 56 percent. In order to prevent extensive starvation, it would be necessary for the Park Service to undertake the slaughter of most of these animals ... We cannot afford, except for the most compelling reasons — which we are convinced do not exist in this case — to permit this impairment of one of the finest properties of the American people.\nDrury went on to state that 19,460 acres (7,880 ha) of land would be flooded, including virgin Ponderosa pine. In order to show that the area was of recreational value, the Park Service constructed the Camas Creek Road through the area.\nThe dam was opposed by the Park Service and conservation organizations on principal as an intrusion into lands that had been made inviolate by their inclusion in a national park, with about a third of the reservoir located on Park Service lands. The precedent established at Hetch Hetchy in Yosemite National Park was not to be repeated. A similar, more difficult fight followed over the proposed Echo Park Dam in Dinosaur National Monument.\n\n\n== Related projects ==\nA related project, the Paradise project on the Clark Fork River just below its confluence with the Flathead, was opposed by local interests. The Paradise project was considered by the Corps of Engineers to be a more desirable project than Glacier Point, but was considered by the Corps to be difficult to develop compared to Glacier View, given the developed nature of the flooded area proposed at Paradise versus the relatively unpopulated Glacier View region.  Other proposed dams were the Smoky Range, Canyon Creek and Spruce Park dams, none of which were built. Hungry Horse Dam was, however,  completed in 1953 by the U.S. Bureau of Reclamation on the South Fork of the Flathead. The Spruce Park reservoir to the south of the park was proposed to have been connected to the Hungry Horse reservoir, with a power generation plant at the conduit's discharge. Paradise Dam is described by the Corps of Engineers as preferable from the point of view of the overall plan, standing on both the Clark Fork River and the Flathead, but the flooding of towns and productive agricultural lands stirred intense local opposition.\nThe 1950 Corps of Engineers report that detailed the Glacier View project also mentioned the potential of the Middle Fork Flathead River for development, and projected a dam at Belton, with a 1,190,000-acre-foot (1.47 km3) reservoir behind a dam developing 330 feet (100 m) of hydraulic head, for a potential generating capacity of 152 MW. As the Middle Fork forms the southwest boundary of Glacier National Park, any reservoir on the Middle Fork near Belton would necessarily flood portions of the park. With the rejection of the Glacier View project, the Belton project never progressed beyond its listing as a potential project.\n\n\n== Description ==\n\nThe proposed Glacier View Dam was to be a 416-foot (127 m) high, 2,100-foot (640 m) long earth embankment dam, impounding a reservoir with a capacity of 3,160,000 acre-feet (3.90 km3) and covering an area of about 48 square miles (120 km2). A gated spillway was to be built to the north side, feeding a tunnel through the abutment. A powerplant at the toe of the dam was planned to house three 70 MW generating units, fed by an intake tower and equipped with a surge tank. The chosen site was to be at river mile 176.5. Alternate sites at Fool Hen Hill (river mile 167) and Bad Rock Canyon (river mile 150) were rejected. The Fool Hen Hill site was found to have a permeable alluvial channel in the right abutment. The Bad Rock Canyon site would have been on the main stem of the Flathead and was also determined to have poor abutment rock, as well as alluvial deposits on the valley floor reaching up to 300 ft (91 m) deep. It would have flooded the Hungry Horse damsite, which was under construction, as well as Lake McDonald in the park.\n\n\n== Present ==\nThe Camas Road joins the Outside North Fork Road just to the east of the damsite. The Forests and Fire Nature Trail is just upstream from the site. The Logging Creek Ranger Station and the small town of Polebridge lie within the proposed reservoir. Within the park, the lower reaches of Camas Creek, Quartz Creek, Bowman Creek and Akokala Creek would have been flooded, along with most of Logging Creek and Logging Lake.\n\n\n== References ==",
+      "wikipedia_url": "https://en.wikipedia.org/wiki/Huckleberry_Fire_Lookout",
+      "wikipedia_text": "The Huckleberry Fire Lookout in Glacier National Park is significant as one of a chain of staffed fire lookout posts within the park. The low two-story timber-construction structure with a pyramidal roof was built in 1933, replacing a similar structure built in 1923. It is one of several similar structures built to a modified version of a plan developed by the U.S. Forest Service.\n\n\n== References ==",
       "summary": "Located near the park&#x27;s western boundary on the North Fork Flathead River."
     }
   ],
   "metadata": {
-    "total_peaks": 185,
-    "peaks_with_articles": 161,
-    "peaks_without_articles": 24,
+    "total_peaks": 184,
+    "peaks_with_articles": 163,
+    "peaks_without_articles": 21,
     "generated_at": "2026-01-13T15:26:20.721866"
   }
 }

--- a/test/test_peaks.py
+++ b/test/test_peaks.py
@@ -1,12 +1,21 @@
+import csv
 import io
-from datetime import date
+import json
+import re
+from datetime import date, timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests
 from PIL import Image
 
-from peak.peak import _get_peak_summary, peak
+from peak.peak import (
+    PEAKS_CSV,
+    SCRIPT_DIR,
+    _get_peak_summary,
+    peak,
+    select_peak,
+)
 from peak.sat import peak_sat, prepare_peak_upload, upload_peak
 
 
@@ -46,23 +55,25 @@ def sample_image():
 
 
 def test_peak_selection(mock_env_vars):
-    """Test random peak selection"""
-    mock_rng = MagicMock()
-    mock_rng.choice = MagicMock(
-        side_effect=lambda peaks: peaks[0]  # Always pick the first peak
-    )
-    with patch("random.Random", return_value=mock_rng) as mock_random_cls:
-        result = peak(test=True)
+    """Test peak selection returns a correctly formatted result"""
+    result = peak(test=True)
 
-        # Check that Random was instantiated with today's date as seed
-        mock_random_cls.assert_called_once_with(date.today().strftime("%Y%m%d"))
+    peak_name, peak_img, peak_map = result
+    assert isinstance(peak_name, str)
+    assert "ft." in peak_name
+    assert peak_map.startswith("https://www.google.com/maps/place/")
+    assert peak_img is None  # Should be None in test mode
 
-        # Verify result format
-        peak_name, peak_img, peak_map = result
-        assert isinstance(peak_name, str)
-        assert "ft." in peak_name
-        assert peak_map.startswith("https://www.google.com/maps/place/")
-        assert peak_img is None  # Should be None in test mode
+
+def test_peak_selection_uses_todays_date(mock_env_vars):
+    """Test that the peak shown matches the one selected for today's date"""
+    with open(PEAKS_CSV, encoding="utf-8") as f:
+        peaks = list(csv.DictReader(f))
+
+    expected = select_peak(peaks, date.today())
+    peak_name, _, _ = peak(test=True)
+
+    assert peak_name.startswith(f"{expected['name']} - {expected['elevation']} ft.")
 
 
 def test_peak_sat_image_generation(mock_env_vars, sample_peak_data):
@@ -176,6 +187,134 @@ def test_peak_csv_read():
     assert " - " in peak_name  # Should contain name and elevation
     assert "ft." in peak_name
     assert "@" in peak_map  # Should contain coordinates
+
+
+class TestSelectPeak:
+    """Tests for the date-seeded peak rotation"""
+
+    @pytest.fixture
+    def peaks(self):
+        return [{"name": f"Peak {i}", "elevation": str(i)} for i in range(10)]
+
+    def test_deterministic_for_a_given_day(self, peaks):
+        """The same date always yields the same peak"""
+        day = date(2026, 7, 27)
+        assert select_peak(peaks, day) == select_peak(peaks, day)
+
+    def test_every_peak_used_exactly_once_per_cycle(self, peaks):
+        """A full cycle of len(peaks) days covers the whole list with no repeats"""
+        start = date(2026, 1, 1)
+        picked = [
+            select_peak(peaks, start + timedelta(days=i)) for i in range(len(peaks))
+        ]
+
+        names = [p["name"] for p in picked]
+        assert sorted(names) == sorted(p["name"] for p in peaks)
+        assert len(set(names)) == len(peaks)
+
+    def test_consecutive_cycles_use_different_orders(self, peaks):
+        """Each cycle reshuffles rather than repeating the same sequence"""
+        start = date(2026, 1, 1)
+        n = len(peaks)
+        first = [
+            select_peak(peaks, start + timedelta(days=i))["name"] for i in range(n)
+        ]
+        second = [
+            select_peak(peaks, start + timedelta(days=n + i))["name"] for i in range(n)
+        ]
+
+        assert sorted(first) == sorted(second)  # same peaks
+        assert first != second  # different order
+
+    def test_handles_dates_before_the_epoch(self, peaks):
+        """Dates before the cycle epoch still index inside the list"""
+        from peak.peak import PEAK_CYCLE_EPOCH
+
+        for i in range(1, 40):
+            selected = select_peak(peaks, PEAK_CYCLE_EPOCH - timedelta(days=i))
+            assert selected in peaks
+
+    def test_real_peak_list_has_no_duplicates(self):
+        """The shipped CSV should not list the same peak twice"""
+        with open(PEAKS_CSV, encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+
+        names = [r["name"] for r in rows]
+        assert len(names) == len(set(names)), "duplicate peak names in PeaksCSV.csv"
+
+    def test_works_from_any_working_directory(
+        self, mock_env_vars, tmp_path, monkeypatch
+    ):
+        """Data files are resolved relative to the module, not the cwd"""
+        monkeypatch.chdir(tmp_path)
+        peak_name, _, _ = peak(test=True)
+        assert "ft." in peak_name
+
+
+class TestPeakDataFiles:
+    """Consistency checks across the shipped peak data files"""
+
+    @pytest.fixture
+    def rows(self):
+        with open(PEAKS_CSV, encoding="utf-8") as f:
+            return list(csv.DictReader(f))
+
+    @pytest.fixture
+    def wiki(self):
+        with open(SCRIPT_DIR / "peaks_wikipedia.json", encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_csv_and_wikipedia_json_agree(self, rows, wiki):
+        """
+        The JSON must carry the same names and coords as the CSV, in order.
+
+        _get_peak_summary matches on exact name plus coordinates, so a name that
+        drifts between the two files silently drops that peak's summary.
+        """
+        csv_keys = [(r["name"], round(float(r["lat"]), 5)) for r in rows]
+        json_keys = [(p["name"], round(p["lat"], 5)) for p in wiki["peaks"]]
+        assert csv_keys == json_keys
+
+    def test_every_summary_is_reachable(self, wiki):
+        """Each summary in the JSON can actually be looked up by peak.py"""
+        for p in wiki["peaks"]:
+            if p.get("summary"):
+                assert _get_peak_summary(p["name"], p["lat"], p["lon"]) == p["summary"]
+
+    def test_no_wikipedia_csv_matches_has_article_flags(self, wiki):
+        """peaks_no_wikipedia.csv lists exactly the peaks with no article"""
+        with open(SCRIPT_DIR / "peaks_no_wikipedia.csv", encoding="utf-8") as f:
+            listed = {r["name"] for r in csv.DictReader(f)}
+
+        assert listed == {p["name"] for p in wiki["peaks"] if not p["has_article"]}
+
+    def test_metadata_counts_are_current(self, wiki):
+        """The metadata block reflects the actual contents"""
+        peaks = wiki["peaks"]
+        with_article = sum(1 for p in peaks if p["has_article"])
+        assert wiki["metadata"]["total_peaks"] == len(peaks)
+        assert wiki["metadata"]["peaks_with_articles"] == with_article
+        assert wiki["metadata"]["peaks_without_articles"] == len(peaks) - with_article
+
+    def test_no_disambiguation_pages_stored(self, wiki):
+        """Stored article text should be a real article, not a disambiguation page"""
+        pattern = re.compile(r"\b(may refer to|can refer to|could be)\b", re.IGNORECASE)
+        bad = [
+            p["name"]
+            for p in wiki["peaks"]
+            if pattern.search((p["wikipedia_text"] or "")[:200])
+        ]
+        assert not bad, f"disambiguation pages stored for: {bad}"
+
+    def test_article_links_are_consistent_with_flags(self, wiki):
+        """has_article must agree with whether a url and text are present"""
+        for p in wiki["peaks"]:
+            if p["has_article"]:
+                assert p["wikipedia_url"] and p["wikipedia_text"], p["name"]
+            else:
+                assert p["wikipedia_url"] is None and p["wikipedia_text"] is None, p[
+                    "name"
+                ]
 
 
 class TestGetPeakSummary:


### PR DESCRIPTION
The daily peak was drawn with random.choice seeded on the date. The seeding itself was sound, but drawing with replacement meant ~22 peaks went unshown in a given year while others repeated up to 6 times, with gaps between repeats reaching 1506 days.

Replace it with a seeded shuffle: each cycle of len(peaks) days gets its own shuffled order, indexed by the day's offset. Every peak now appears exactly once per cycle. Selection stays deterministic per date, so the hourly and daily runs still agree.

Alongside that, correct several errors in the peak data:

- PeaksCSV.csv listed Bear Mountain twice (8841 and 8796 ft), giving it double the frequency of every other peak. Wikipedia's article confirms 8841 ft at coordinates matching that row, so the 8796 row is dropped.

- Four peaks had their CSV spelling corrected without the matching update to peaks_wikipedia.json. Since _get_peak_summary matches on exact name, Mount Henkel, Amphitheater Mountain, Curly Bear Mountain and Mount Phillips were silently showing no summary at all.

- Four peaks were linked to articles about something else entirely, and Bear Mountain's summary described Curly Bear Mountain, 39 km away. Verifying by coordinate instead of title found the right articles for Bear Mountain, Ninaki Peak and Huckleberry Mountain; Chief Lodgepole Peak has no article, so its link is cleared and its (accurate) summary kept. Ninaki's summary also claimed the name means "chief" -- it refers to the war chief's wife.

- Mount Gould, Triple Divide Peak and Mount Ellsworth stored disambiguation pages rather than articles. Repointed to the real ones, which let Mount Ellsworth's placeholder summary be replaced with the naming detail its own article carried.

The root cause was verify_article accepting a match on a Montana mention OR a coordinate match. Nearly every Glacier peak article mentions Montana, so the coordinate check never gated anything and any plausible search hit passed. Coordinates now decide when the article has them.

Peak data files are resolved relative to the module rather than the working directory, and the stale metadata block and peaks_no_wikipedia listing are brought back in sync.