### PR TITLE
Skip videos and redraw when the image of the day is unusable

### DIFF
--- a/image_otd/flickr.py
+++ b/image_otd/flickr.py
@@ -7,10 +7,12 @@ import time
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
+from io import BytesIO
 from pathlib import Path
 from urllib.error import URLError
 
 from flickrapi import FlickrAPI
+from PIL import Image
 
 from shared.logging_config import get_logger
 from shared.settings import get_settings
@@ -20,6 +22,10 @@ logger = get_logger(__name__)
 
 class FlickrAPIError(Exception):
     """Raised when Flickr API operations fail"""
+
+
+class FlickrRateLimitError(FlickrAPIError):
+    """Raised when Flickr rate-limits us — retrying another photo won't help"""
 
 
 @dataclass
@@ -34,6 +40,8 @@ class FlickrImage:
 
 
 _MIN_WIDTH = 1040  # 2x of 520px email column
+_MAX_PHOTO_ATTEMPTS = 5  # candidate photos to try before giving up for the day
+_SAVE_LOC = Path("email_images/today/raw_image_otd.jpg")
 
 
 def _best_image_url(flickr: FlickrAPI, photo_id: str) -> str:
@@ -43,28 +51,135 @@ def _best_image_url(flickr: FlickrAPI, photo_id: str) -> str:
     """
     sizes = flickr.photos.getSizes(photo_id=photo_id)["sizes"]["size"]
 
+    # Videos in the photostream list player/MP4 entries alongside their still
+    # frames. Those aren't images, so picking one hands PIL a video file. The
+    # still-frame sizes are tagged "photo" and stay usable.
+    images = [s for s in sizes if s.get("media", "photo") == "photo"]
+    if not images:
+        raise FlickrAPIError(f"No image sizes available for photo {photo_id}")
+
     # Sort by width ascending
-    sizes.sort(key=lambda s: int(s["width"]))
+    images.sort(key=lambda s: int(s["width"]))
 
     # First size >= _MIN_WIDTH (smallest sufficient)
-    for size in sizes:
+    for size in images:
         if int(size["width"]) >= _MIN_WIDTH:
             return size["source"]
 
     # Nothing large enough — use the biggest available
-    return sizes[-1]["source"]
+    return images[-1]["source"]
+
+
+def _check_is_image(url: str, content_type: str, data: bytes) -> None:
+    """Reject a download that isn't a usable image before it reaches the email.
+
+    Raises:
+        FlickrAPIError: If the response is empty, not an image, or unreadable.
+    """
+    if not data:
+        raise FlickrAPIError(f"Empty response downloading image from {url}")
+
+    if content_type and not content_type.split(";")[0].strip().startswith("image/"):
+        raise FlickrAPIError(f"Downloaded content is not an image ({content_type})")
+
+    try:
+        with Image.open(BytesIO(data)) as image:
+            image.verify()
+    except Exception as e:
+        raise FlickrAPIError(f"Downloaded image is unreadable: {e!s}") from e
+
+
+def _download_image(pic_url: str) -> bytes:
+    """Download an image, retrying with backoff on rate limiting.
+
+    Returns:
+        bytes: The verified image data.
+
+    Raises:
+        FlickrRateLimitError: If Flickr keeps returning HTTP 429.
+        FlickrAPIError: If the download fails or isn't a usable image.
+    """
+    req = urllib.request.Request(  # noqa: S310
+        pic_url,
+        headers={
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Accept-Encoding": "gzip, deflate, br",
+            "DNT": "1",
+            "Connection": "keep-alive",
+            "Upgrade-Insecure-Requests": "1",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "none",
+            "Cache-Control": "max-age=0",
+        },
+    )
+
+    max_retries = 2  # retry count for image download
+    backoff = 4  # initial backoff seconds for 429 responses
+    for attempt in range(max_retries):
+        try:
+            with urllib.request.urlopen(req) as response:  # noqa: S310
+                if response.status == 429:
+                    # Too Many Requests, backoff and retry
+                    if attempt < max_retries - 1:
+                        wait = backoff * (2**attempt)
+                        logger.warning(
+                            "Flickr 429 Too Many Requests, backing off %ds", wait
+                        )
+                        time.sleep(wait)
+                        continue
+                    raise FlickrRateLimitError(
+                        "Too many requests (HTTP 429) after retries."
+                    )
+                content_type = response.headers.get("Content-Type", "")
+                data = response.read()
+        except URLError as e:
+            # If it's a 429, handle backoff, else raise
+            if hasattr(e, "code") and e.code == 429:
+                if attempt < max_retries - 1:
+                    wait = backoff * (2**attempt)
+                    logger.warning(
+                        "Flickr 429 Too Many Requests, backing off %ds", wait
+                    )
+                    time.sleep(wait)
+                    continue
+                raise FlickrRateLimitError(
+                    "Too many requests (HTTP 429) after retries."
+                ) from e
+            raise FlickrAPIError(f"Failed to download image: {e!s}") from e
+
+        _check_is_image(pic_url, content_type, data)
+        return data
+
+    raise FlickrRateLimitError("Too many requests (HTTP 429) after retries.")
+
+
+def _random_photo(
+    flickr: FlickrAPI, user_id: str, rng: random.Random, total: int
+) -> dict | None:
+    """Draw one random photo from the photostream, or None if the page is empty."""
+    page = rng.randint(1, total)
+    photos = flickr.photos.search(user_id=user_id, per_page="1", page=page)
+    found = photos["photos"]["photo"]
+    return found[0] if found else None
 
 
 def get_flickr() -> FlickrImage:
     """
     Retrieve a random image from the Glacier National Park's Flickr account.
 
+    The photo is chosen from a date-seeded RNG, so every run on a given day
+    makes the same draws. A candidate that can't be turned into a usable image
+    (a video, a broken download) is skipped and the next draw is tried, so one
+    bad photo doesn't cost the whole day its image.
+
     Returns:
         FlickrImage: Object containing image path, title, and link
 
     Raises:
-        FlickrAPIError: If API calls fail or environment variables are missing
-        URLError: If image download fails
+        FlickrAPIError: If API calls fail or no candidate yields a usable image
     """
     try:
         settings = get_settings()
@@ -73,86 +188,43 @@ def get_flickr() -> FlickrImage:
         )
         photos = flickr.photos.search(user_id=settings.GLACIERNPS_UID, per_page="1")
         total = int(photos["photos"]["total"])
-
-        rng = random.Random(datetime.today().strftime("%Y:%m:%d"))  # noqa: S311
-        potd_num = rng.randint(1, total)
-        photos = flickr.photos.search(
-            user_id=settings.GLACIERNPS_UID, per_page="1", page=potd_num
-        )
-
-        # Retry if no photos found
-        while len(photos["photos"]["photo"]) == 0:
-            potd_num = rng.randint(1, total)
-            photos = flickr.photos.search(
-                user_id=settings.GLACIERNPS_UID, per_page="1", page=potd_num
-            )
-
-        selected = photos["photos"]["photo"][0]
-        photo_id = selected["id"]
-        title = selected["title"]
-
-        pic_url = _best_image_url(flickr, photo_id)
-        save_loc = Path("email_images/today/raw_image_otd.jpg")
-        save_loc.parent.mkdir(parents=True, exist_ok=True)
-
-        req = urllib.request.Request(  # noqa: S310
-            pic_url,
-            headers={
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.9",
-                "Accept-Encoding": "gzip, deflate, br",
-                "DNT": "1",
-                "Connection": "keep-alive",
-                "Upgrade-Insecure-Requests": "1",
-                "Sec-Fetch-Dest": "document",
-                "Sec-Fetch-Mode": "navigate",
-                "Sec-Fetch-Site": "none",
-                "Cache-Control": "max-age=0",
-            },
-        )
-
-        max_retries = 2  # retry count for image download
-        backoff = 4  # initial backoff seconds for 429 responses
-        for attempt in range(max_retries):
-            try:
-                with (
-                    urllib.request.urlopen(req) as response,  # noqa: S310
-                    open(save_loc, "wb") as out_file,
-                ):
-                    if response.status == 429:
-                        # Too Many Requests, backoff and retry
-                        if attempt < max_retries - 1:
-                            wait = backoff * (2**attempt)
-                            logger.warning(
-                                "Flickr 429 Too Many Requests, backing off %ds", wait
-                            )
-                            time.sleep(wait)
-                            continue
-                        raise FlickrAPIError(
-                            "Too many requests (HTTP 429) after retries."
-                        )
-                    out_file.write(response.read())
-                break
-            except URLError as e:
-                # If it's a 429, handle backoff, else raise
-                if hasattr(e, "code") and e.code == 429:
-                    if attempt < max_retries - 1:
-                        wait = backoff * (2**attempt)
-                        logger.warning(
-                            "Flickr 429 Too Many Requests, backing off %ds", wait
-                        )
-                        time.sleep(wait)
-                        continue
-                    raise FlickrAPIError(
-                        "Too many requests (HTTP 429) after retries."
-                    ) from e
-                raise FlickrAPIError(f"Failed to download image: {e!s}") from e
-
-        link = f"https://flickr.com/photos/glaciernps/{photo_id}"
-        return FlickrImage(save_loc, title, link)
-
     except KeyError as e:
         raise FlickrAPIError(f"Missing environment variable: {e!s}") from e
     except Exception as e:
         raise FlickrAPIError(f"Flickr API error: {e!s}") from e
+
+    rng = random.Random(datetime.today().strftime("%Y:%m:%d"))  # noqa: S311
+    last_error = "no candidates drawn"
+
+    for attempt in range(1, _MAX_PHOTO_ATTEMPTS + 1):
+        try:
+            selected = _random_photo(flickr, settings.GLACIERNPS_UID, rng, total)
+            if selected is None:
+                last_error = "empty search page"
+                continue
+
+            pic_url = _best_image_url(flickr, selected["id"])
+            data = _download_image(pic_url)
+        except FlickrRateLimitError:
+            # Another photo would hit the same limit — give up for this run
+            raise
+        except Exception as e:
+            last_error = str(e)
+            logger.warning(
+                "Flickr candidate %d/%d unusable, drawing another: %s",
+                attempt,
+                _MAX_PHOTO_ATTEMPTS,
+                e,
+            )
+            continue
+
+        _SAVE_LOC.parent.mkdir(parents=True, exist_ok=True)
+        with open(_SAVE_LOC, "wb") as out_file:
+            out_file.write(data)
+
+        link = f"https://flickr.com/photos/glaciernps/{selected['id']}"
+        return FlickrImage(_SAVE_LOC, selected["title"], link)
+
+    raise FlickrAPIError(
+        f"No usable photo after {_MAX_PHOTO_ATTEMPTS} attempts: {last_error}"
+    )

--- a/test/test_image_otd.py
+++ b/test/test_image_otd.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 from urllib.error import URLError
@@ -5,7 +6,12 @@ from urllib.error import URLError
 import pytest
 from PIL import Image
 
-from image_otd.flickr import FlickrAPIError, FlickrImage, _best_image_url, get_flickr
+from image_otd.flickr import (
+    FlickrAPIError,
+    FlickrImage,
+    _best_image_url,
+    get_flickr,
+)
 from image_otd.image_otd import (
     ImageProcessingError,
     get_image_otd,
@@ -40,6 +46,14 @@ def mock_flickr_response():
             ],
         }
     }
+
+
+@pytest.fixture
+def jpeg_bytes():
+    """Real JPEG bytes — downloads are PIL-verified before being saved."""
+    buffer = BytesIO()
+    Image.new("RGB", (1600, 900), color="blue").save(buffer, format="JPEG")
+    return buffer.getvalue()
 
 
 @pytest.fixture
@@ -97,6 +111,49 @@ class TestBestImageUrl:
         result = _best_image_url(mock_api, "123")
         assert result == "https://flickr.com/800.jpg"
 
+    def test_skips_video_sizes(self):
+        """Video player entries must never be chosen — they aren't images."""
+        mock_api = Mock()
+        mock_api.photos.getSizes.return_value = {
+            "sizes": {
+                "size": [
+                    {
+                        "width": "1024",
+                        "source": "https://flickr.com/1024.jpg",
+                        "media": "photo",
+                    },
+                    {
+                        "width": "1280",
+                        "source": "https://flickr.com/play/720p/",
+                        "media": "video",
+                    },
+                    {
+                        "width": "1600",
+                        "source": "https://flickr.com/1600.jpg",
+                        "media": "photo",
+                    },
+                ]
+            }
+        }
+        result = _best_image_url(mock_api, "123")
+        assert result == "https://flickr.com/1600.jpg"
+
+    def test_raises_when_only_video_sizes(self):
+        mock_api = Mock()
+        mock_api.photos.getSizes.return_value = {
+            "sizes": {
+                "size": [
+                    {
+                        "width": "1280",
+                        "source": "https://flickr.com/play/720p/",
+                        "media": "video",
+                    }
+                ]
+            }
+        }
+        with pytest.raises(FlickrAPIError, match="No image sizes"):
+            _best_image_url(mock_api, "123")
+
     def test_exact_threshold_match(self):
         """A size exactly at 1040px should be picked."""
         mock_api = Mock()
@@ -112,7 +169,9 @@ class TestBestImageUrl:
         assert result == "https://flickr.com/1040.jpg"
 
 
-def test_get_flickr_success(mock_env_vars, mock_flickr_response, mock_sizes_response):
+def test_get_flickr_success(
+    mock_env_vars, mock_flickr_response, mock_sizes_response, jpeg_bytes
+):
     with (
         patch("image_otd.flickr.FlickrAPI") as MockFlickrAPI,
         patch("image_otd.flickr.urllib.request.urlopen") as mock_urlopen,
@@ -127,7 +186,8 @@ def test_get_flickr_success(mock_env_vars, mock_flickr_response, mock_sizes_resp
         # Setup mock urlopen
         mock_response = Mock()
         mock_response.status = 200
-        mock_response.read.return_value = b"fake image data"
+        mock_response.headers = {"Content-Type": "image/jpeg"}
+        mock_response.read.return_value = jpeg_bytes
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
         # Setup mock open
@@ -181,6 +241,103 @@ def test_get_flickr_download_error(
 
         with pytest.raises(FlickrAPIError, match="Failed to download image"):
             get_flickr()
+
+
+def test_get_flickr_redraws_past_a_video(
+    mock_env_vars, mock_sizes_response, jpeg_bytes
+):
+    """A video (no image sizes) should cost one draw, not the whole day."""
+    with (
+        patch("image_otd.flickr.FlickrAPI") as MockFlickrAPI,
+        patch("image_otd.flickr.urllib.request.urlopen") as mock_urlopen,
+        patch("builtins.open", create=True) as mock_open,
+    ):
+
+        def photo(photo_id, title):
+            return {
+                "photos": {"total": "100", "photo": [{"id": photo_id, "title": title}]}
+            }
+
+        mock_api = Mock()
+        mock_api.photos.search.side_effect = [
+            photo("total", "ignored"),  # per_page=1 total query
+            photo("video_id", "A video"),  # first draw — video only
+            photo("photo_id", "A photo"),  # redraw — usable
+        ]
+        video_sizes = {
+            "sizes": {
+                "size": [
+                    {
+                        "width": "1280",
+                        "source": "https://flickr.com/play/720p/",
+                        "media": "video",
+                    }
+                ]
+            }
+        }
+        mock_api.photos.getSizes.side_effect = [video_sizes, mock_sizes_response]
+        MockFlickrAPI.return_value = mock_api
+
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "image/jpeg"}
+        mock_response.read.return_value = jpeg_bytes
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+        mock_open.return_value.__enter__.return_value = Mock()
+
+        result = get_flickr()
+
+        assert result.title == "A photo"
+        assert result.link == "https://flickr.com/photos/glaciernps/photo_id"
+
+
+def test_get_flickr_gives_up_after_max_attempts(
+    mock_env_vars, mock_flickr_response, mock_sizes_response
+):
+    """Every candidate failing raises, rather than looping forever."""
+    with (
+        patch("image_otd.flickr.FlickrAPI") as MockFlickrAPI,
+        patch("image_otd.flickr.urllib.request.urlopen") as mock_urlopen,
+    ):
+        mock_api = Mock()
+        mock_api.photos.search.return_value = mock_flickr_response
+        mock_api.photos.getSizes.return_value = mock_sizes_response
+        MockFlickrAPI.return_value = mock_api
+
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "image/jpeg"}
+        mock_response.read.return_value = b"not really a jpeg"
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        with pytest.raises(FlickrAPIError, match="No usable photo after 5 attempts"):
+            get_flickr()
+
+
+def test_get_flickr_rejects_non_image_download(
+    mock_env_vars, mock_flickr_response, mock_sizes_response
+):
+    """A non-image response (e.g. video, error page) must not be saved."""
+    with (
+        patch("image_otd.flickr.FlickrAPI") as MockFlickrAPI,
+        patch("image_otd.flickr.urllib.request.urlopen") as mock_urlopen,
+        patch("builtins.open", create=True) as mock_open,
+    ):
+        mock_api = Mock()
+        mock_api.photos.search.return_value = mock_flickr_response
+        mock_api.photos.getSizes.return_value = mock_sizes_response
+        MockFlickrAPI.return_value = mock_api
+
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "video/mp4"}
+        mock_response.read.return_value = b"\x00\x00\x00\x1cftypM4V "
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        with pytest.raises(FlickrAPIError, match="not an image"):
+            get_flickr()
+
+        assert not [c for c in mock_open.call_args_list if "wb" in c.args]
 
 
 @pytest.fixture
@@ -356,7 +513,7 @@ def test_get_flickr_url_error_429_retry(
         assert mock_sleep.call_count == 1
 
 
-def test_get_flickr_no_photos_found(mock_env_vars, mock_sizes_response):
+def test_get_flickr_no_photos_found(mock_env_vars, mock_sizes_response, jpeg_bytes):
     """Test retry loop when initial search returns no photos."""
     with (
         patch("image_otd.flickr.FlickrAPI") as MockFlickrAPI,
@@ -387,7 +544,8 @@ def test_get_flickr_no_photos_found(mock_env_vars, mock_sizes_response):
 
         mock_response = Mock()
         mock_response.status = 200
-        mock_response.read.return_value = b"data"
+        mock_response.headers = {"Content-Type": "image/jpeg"}
+        mock_response.read.return_value = jpeg_bytes
         mock_urlopen.return_value.__enter__ = Mock(return_value=mock_response)
         mock_urlopen.return_value.__exit__ = Mock(return_value=False)
 


### PR DESCRIPTION
## Problem

The 8/8 run failed with `PIL.UnidentifiedImageError: cannot identify image file 'email_images/today/raw_image_otd.jpg'`.

That day's draw was a **video**. Flickr's `photos.getSizes` returns player/MP4 entries alongside the video's still frames, and `_best_image_url` ranked every entry by width — so the 1280px **720p MP4** won over the 1600px JPEG. It downloaded 8MB of `video/mp4` into `raw_image_otd.jpg` and PIL rejected it. 46 of the photostream's 3448 items are videos, so this lands roughly one day in 75.

Worse, the failure stuck for the whole day: `image_otd` is date-deterministic, so every hourly run redrew the same video and failed the same way.

## Fix

- `_best_image_url` filters to sizes tagged `media == "photo"`. A video's still frames are tagged that way and stay usable.
- `_check_is_image` validates each download (non-empty, `image/*` content type, decodes under PIL) *before* anything is written. Previously the save path was opened `wb` — truncating it — before the response was inspected, so a bad response destroyed the previous good file.
- `get_flickr` now draws up to 5 candidates, skipping any that can't produce a usable image: video-only sizes, an empty search page, a failed download, undecodable bytes. Each skip logs a warning. The empty-page case previously had its own unbounded `while` loop; it's now on the same attempt budget.
- The RNG is still seeded from the date, so the replacement photo is deterministic — hourly runs agree with each other and with the LKG cache.
- Rate limiting raises `FlickrRateLimitError` and aborts rather than redrawing, since another candidate would hit the same 429s. The next hourly run retries from scratch.

## Verification

Replaying 8/8 against the live API now returns the 1600×900 still of "Clearing Snow at Logan Pass 2024". With the first candidate forced to fail, it logs the skip and returns "Running the Avalanche Trail" instead.

New tests cover video-size filtering, the redraw, exhausting the attempt budget, and rejecting a non-image download; download mocks now serve real JPEG bytes since downloads are verified. Full suite: 692 passed. ruff and ty clean.