### PR TITLE
Keep fork pull requests off the self-hosted runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Custom labels for the self-hosted runner on the Raspberry Pi. Without this,
+# actionlint rejects `runs-on: [self-hosted, gnpic]` as an unknown label.
+self-hosted-runner:
+  labels:
+    - gnpic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,31 @@ on:
   pull_request:
     branches: [ main ]
 
+# Empty values so modules exercise their graceful-degradation paths in CI.
+env:
+  NPS: ""
+  DRIP_TOKEN: ""
+  DRIP_ACCOUNT: ""
+  FTP_PASSWORD: ""
+  FTP_USERNAME: ""
+  FTP_SERVER: ""
+  ALERTS_PWD: ""
+  BC_TOKEN: ""
+  BC_STORE_HASH: ""
+  FLICKR_KEY: ""
+  FLICKR_SECRET: ""
+  GLACIERNPS_UID: ""
+  webcam_ftp_user: ""
+  webcam_ftp_pword: ""
+  timelapse_server: ""
+  MAPBOX_TOKEN: ""
+  MAPBOX_ACCOUNT: ""
+  MAPBOX_STYLE: ""
+  SUNSETHUE_KEY: ""
+  GOOGLE_APPLICATION_CREDENTIALS: ""
+  NOTICES_SPREADSHEET_ID: ""
+  ENVIRONMENT: "development"
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest
@@ -29,34 +54,18 @@ jobs:
   unit-and-integration-test:
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            shell: bash
-          - os: windows-latest
-            shell: pwsh
-          - os: macos-latest
-            shell: bash
-          - os: [self-hosted, gnpic]
-            shell: bash
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv (Unix)
-        if: runner.os != 'Windows' && !contains(matrix.os, 'self-hosted')
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "0.8.10"
-
-      - name: Install uv (Windows)
-        if: runner.os == 'Windows'
+      - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.8.10"
 
       - name: Install Python 3.11
-        if: "!contains(matrix.os, 'self-hosted')"
         run: uv python install 3.11
 
       - name: Install dependencies
@@ -75,29 +84,6 @@ jobs:
           New-Item -ItemType Directory -Force -Path email_images/today/
 
       - name: Run tests
-        env:
-          NPS: ""
-          DRIP_TOKEN: ""
-          DRIP_ACCOUNT: ""
-          FTP_PASSWORD: ""
-          FTP_USERNAME: ""
-          FTP_SERVER: ""
-          ALERTS_PWD: ""
-          BC_TOKEN: ""
-          BC_STORE_HASH: ""
-          FLICKR_KEY: ""
-          FLICKR_SECRET: ""
-          GLACIERNPS_UID: ""
-          webcam_ftp_user: ""
-          webcam_ftp_pword: ""
-          timelapse_server: ""
-          MAPBOX_TOKEN: ""
-          MAPBOX_ACCOUNT: ""
-          MAPBOX_STYLE: ""
-          SUNSETHUE_KEY: ""
-          GOOGLE_APPLICATION_CREDENTIALS: ""
-          NOTICES_SPREADSHEET_ID: ""
-          ENVIRONMENT: "development"
         run: |
           echo "Running test suite with coverage on ${{ matrix.os }}..."
           uv run pytest test/ --cov=. --cov-report xml --tb=short
@@ -108,3 +94,32 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: amerorchis/glacier_daily
+
+  # Runs on the production Raspberry Pi, which holds decrypted secrets and sits
+  # on the tailnet. `uv sync` and pytest both execute code from the PR head, so
+  # this job must never run for a pull request opened from a fork.
+  arm-test:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, gnpic]
+    timeout-minutes: 10
+    env:
+      # python-build-standalone's armv7 3.11 segfaults on this Pi, so uv must
+      # never fetch one. The interpreter to use instead comes from UV_PYTHON in
+      # the runner's own .env on the box.
+      UV_PYTHON_DOWNLOADS: "never"
+    steps:
+      - uses: actions/checkout@v4
+
+      # uv and Python 3.11 are preinstalled on the Pi.
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev
+
+      - name: Create directory
+        run: |
+          mkdir -p email_images/today/
+
+      - name: Run tests
+        run: |
+          echo "Running test suite with coverage on self-hosted ARM..."
+          uv run pytest test/ --cov=. --cov-report xml --tb=short


### PR DESCRIPTION
The self-hosted Pi was one entry in the test matrix, and `tests.yml` runs on `pull_request`. This repo is public, so an approved fork PR would run its own `conftest.py` and its own `uv.lock` through `uv sync` and pytest on that machine. The runner account had passwordless sudo, so that meant root on a box holding decrypted production secrets and sitting on the tailnet.

## Change

The Pi moves into its own `arm-test` job, gated on the pull request originating from this repo:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

A job-level `if` is required rather than a step-level one — a matrix entry cannot be dropped conditionally, and guarding individual steps would still let `actions/checkout` place the fork's code on the machine.

## Fallout from removing the matrix entry

- The two `Install uv` steps only differed by the `!contains(matrix.os, 'self-hosted')` condition threaded through the Unix variant, so they collapse into one, and `Install Python 3.11` loses its condition.
- The matrix returns to a plain `os:` list. Its `shell:` key was never referenced — the Windows steps declare `shell: pwsh` themselves.
- The env block moves to workflow level so the two test jobs cannot drift apart.

## UV_PYTHON_DOWNLOADS

`arm-test` pins `UV_PYTHON_DOWNLOADS=never`, because python-build-standalone's armv7 3.11 segfaults on this Pi. The interpreter to use instead comes from `UV_PYTHON` in the runner's own `.env` on the box, since that path is machine-specific.

## actionlint

The `gnpic` label now appears in a literal `runs-on`, where actionlint checks it; inside the matrix it never was. Hence the new `.github/actionlint.yaml`.

## Out of band

The runner itself was moved off the `pi` account onto an unprivileged `ghrunner` user that cannot sudo and cannot read any secret on the box. The full suite was validated there before cutover (692 passed). This PR is the first live run of `arm-test` under that user.